### PR TITLE
Require ansible-base 2.9.10+

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: '>=2.9.10'


### PR DESCRIPTION
##### SUMMARY
State that the collection requires 2.9.10 or higher

##### ISSUE TYPE
- Bugfix Pull Request
