### PR TITLE
Add codecov.yml to fix file mapping

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+   - "/ansible_collections/community/proxysql/::"


### PR DESCRIPTION
Resolves #3 

Add codecov.yml to strip the github actions workingdir from the codecov file paths.