### PR TITLE
Add support for pre-hashing passwords in proxysql_mysql_users module

### DIFF
--- a/plugins/modules/proxysql_mysql_users.py
+++ b/plugins/modules/proxysql_mysql_users.py
@@ -161,7 +161,7 @@ stdout:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
 from ansible.module_utils.six import iteritems
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_bytes
 from hashlib import sha1
 
 # ===========================================
@@ -191,7 +191,7 @@ def load_config_to_runtime(cursor):
 
 
 def mysql_native_password(cleartext_password):
-    mysql_native_encrypted_password = "*" + sha1(sha1(cleartext_password.encode('utf-8')).digest()).hexdigest().upper()
+    mysql_native_encrypted_password = "*" + sha1(sha1(to_bytes(cleartext_password)).digest()).hexdigest().upper()
     return mysql_native_encrypted_password
 
 

--- a/plugins/modules/proxysql_mysql_users.py
+++ b/plugins/modules/proxysql_mysql_users.py
@@ -429,7 +429,7 @@ def main():
             username=dict(required=True, type='str'),
             password=dict(no_log=True, type='str'),
             encrypt_password=dict(default=False, type='bool'),
-            encryption_method=dict(default='mysql_native_password', choices=['mysql_native_password']),
+            encryption_method=dict(default='mysql_native_password', choices=list(encryption_method_map.keys())),
             active=dict(type='bool'),
             use_ssl=dict(type='bool'),
             default_hostgroup=dict(type='int'),

--- a/plugins/modules/proxysql_mysql_users.py
+++ b/plugins/modules/proxysql_mysql_users.py
@@ -190,7 +190,7 @@ def load_config_to_runtime(cursor):
     return True
 
 
-def mysql_native_password(cleartext_password):
+def _mysql_native_password(cleartext_password):
     mysql_native_encrypted_password = "*" + sha1(sha1(to_bytes(cleartext_password)).digest()).hexdigest().upper()
     return mysql_native_encrypted_password
 
@@ -201,7 +201,7 @@ def encrypt_cleartext_password(password_to_encrypt, encryption_method):
 
 
 encryption_method_map = {
-    'mysql_native_password': mysql_native_password
+    'mysql_native_password': _mysql_native_password
 }
 
 

--- a/plugins/modules/proxysql_mysql_users.py
+++ b/plugins/modules/proxysql_mysql_users.py
@@ -191,7 +191,7 @@ def load_config_to_runtime(cursor):
 
 
 def mysql_native_password(cleartext_password):
-    mysql_native_encrypted_password = "*" + sha1(sha1(cleartext_password).digest()).hexdigest().upper()
+    mysql_native_encrypted_password = "*" + sha1(sha1(cleartext_password.encode('utf-8')).digest()).hexdigest().upper()
     return mysql_native_encrypted_password
 
 

--- a/tests/integration/targets/test_proxysql_mysql_users/tasks/base_test.yml
+++ b/tests/integration/targets/test_proxysql_mysql_users/tasks/base_test.yml
@@ -15,6 +15,8 @@
     login_user: admin
     login_password: admin
     username: productiondba
+    password: productiondbapassword
+    encrypt_password: true
     state: "{{ test_delete|ternary('absent', 'present') }}"
     save_to_disk: "{{ not test_proxysql_mysql_users_in_memory_only }}"
     load_to_runtime: "{{ not test_proxysql_mysql_users_in_memory_only }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
If user passwords are converted to mysql hashed format using this sequence:
```sql
LOAD MYSQL USERS TO RUNTIME;
SAVE MYSQL USERS FROM RUNTIME;
SAVE MYSQL USERS TO DISK;
```
Then any subsequent calls to the `proxysql_mysql_users` module will treat the user as needing an update to change the password back to cleartext.

This PR simply adds a check for the password provided in mysql hashed form.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`proxysql_mysql_users`

##### ADDITIONAL INFORMATION
The query `WHERE` clause to check the password is changed from:
```sql
 AND password = <cleartext>
```
to:
```sql
 AND password in (<cleartext>, <hashed>)
```
