### PR TITLE
CI tests: add a note not to use tests as an example of writing roles

### DIFF
--- a/tests/integration/targets/setup_proxysql/tasks/main.yml
+++ b/tests/integration/targets/setup_proxysql/tasks/main.yml
@@ -1,3 +1,8 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - import_tasks: install.yml
 - import_tasks: config.yml

--- a/tests/integration/targets/test_proxysql_backend_servers/tasks/main.yml
+++ b/tests/integration/targets/test_proxysql_backend_servers/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 ### tests
 
 - name: "{{ role_name }} | test_create_using_check_mode | test create backend server using check mode"

--- a/tests/integration/targets/test_proxysql_global_variables/tasks/main.yml
+++ b/tests/integration/targets/test_proxysql_global_variables/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: "{{ role_name }} | setvars | populate base variables for tests"
   import_tasks: setvars.yml
 

--- a/tests/integration/targets/test_proxysql_mysql_users/tasks/main.yml
+++ b/tests/integration/targets/test_proxysql_mysql_users/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 ### tests
 
 - name: "{{ role_name }} | test_create_using_check_mode | test create mysql user using check mode"

--- a/tests/integration/targets/test_proxysql_query_rules/tasks/main.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 ### tests
 
 - name: "{{ role_name }} | test_create_using_check_mode | test create query rule using check mode"

--- a/tests/integration/targets/test_proxysql_replication_hostgroups/tasks/main.yml
+++ b/tests/integration/targets/test_proxysql_replication_hostgroups/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 ### tests
 
 - name: "{{ role_name }} | test_create_using_check_mode | test create replication hostgroups using check mode"

--- a/tests/integration/targets/test_proxysql_scheduler/tasks/main.yml
+++ b/tests/integration/targets/test_proxysql_scheduler/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 ### tests
 
 - name: "{{ role_name }} | test_create_using_check_mode | test create scheduler using check mode"


### PR DESCRIPTION
##### SUMMARY
CI tests: add a note not to use tests as an example of writing roles because they are included in release tarballs (discussed at Ansible community meeting)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
CI tests
