### PR TITLE
Missing required lib

### DIFF
--- a/changelogs/fragments/50-refactor-connectors.yaml
+++ b/changelogs/fragments/50-refactor-connectors.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Refactoring of connector presence checking (https://github.com/ansible-collections/community.proxysql/pull/50)
+  - replace MySQL-Python with mysqlclient (https://github.com/ansible-collections/community.proxysql/pull/50)

--- a/changelogs/fragments/50-refactor-connectors.yaml
+++ b/changelogs/fragments/50-refactor-connectors.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-  - Refactoring of connector presence checking (https://github.com/ansible-collections/community.proxysql/pull/50)
-  - replace MySQL-Python with mysqlclient (https://github.com/ansible-collections/community.proxysql/pull/50)
+  - Refactoring of connector presence checking (https://github.com/ansible-collections/community.proxysql/pull/50).
+  - Replace MySQL-Python with mysqlclient in the import error message (https://github.com/ansible-collections/community.proxysql/pull/50).

--- a/plugins/doc_fragments/proxysql.py
+++ b/plugins/doc_fragments/proxysql.py
@@ -41,8 +41,8 @@ options:
     type: path
     default: ''
 requirements:
-   - PyMySQL (Python 2.7 and Python 3.X), or
-   - MySQLdb (Python 2.x)
+   - PyMySQL
+   - mysqlclient
 '''
 
     # Documentation fragment for managing ProxySQL configuration

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -30,7 +30,7 @@ except ImportError:
         HAS_MYSQL_PACKAGE = True
     except ImportError:
         MYSQL_IMP_ERR = 'Cannot find PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) module.'
-        HAS_GITLAB_PACKAGE = False
+        HAS_MYSQL_PACKAGE = False
         mysql_driver = None
 
 

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -46,7 +46,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     config = {}
 
     if not HAS_MYSQL_PACKAGE:
-        module.fail_json(msg=missing_required_lib("PyMySQL"), exception=MYSQL_IMP_ERR)
+        module.fail_json(msg=missing_required_lib("pymysql or MySQLdb"), exception=MYSQL_IMP_ERR)
 
     if config_file and os.path.exists(config_file):
         config['read_default_file'] = config_file

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -29,7 +29,7 @@ except ImportError:
         _mysql_cursor_param = 'cursorclass'
         HAS_MYSQL_PACKAGE = True
     except ImportError:
-        MYSQL_IMP_ERR = 'Cannot find PyMySQL or mysqlclient module.'
+        MYSQL_IMP_ERR = 'Cannot find PyMySQL or mysqlclient library.'
         HAS_MYSQL_PACKAGE = False
         mysql_driver = None
 

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -29,7 +29,7 @@ except ImportError:
         _mysql_cursor_param = 'cursorclass'
         HAS_MYSQL_PACKAGE = True
     except ImportError:
-        MYSQL_IMP_ERR = 'Cannot find PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) module.'
+        MYSQL_IMP_ERR = 'Cannot find PyMySQL or mysqlclient module.'
         HAS_MYSQL_PACKAGE = False
         mysql_driver = None
 

--- a/plugins/modules/proxysql_backend_servers.py
+++ b/plugins/modules/proxysql_backend_servers.py
@@ -158,7 +158,7 @@ stdout:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
+from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
 
@@ -193,9 +193,6 @@ def perform_checks(module):
             module.fail_json(
                 msg="max_replication_lag must be set between 0 and 102400"
             )
-
-    if mysql_driver is None:
-        module.fail_json(msg=mysql_driver_fail_msg)
 
 
 def save_config_to_disk(cursor):

--- a/plugins/modules/proxysql_global_variables.py
+++ b/plugins/modules/proxysql_global_variables.py
@@ -72,7 +72,7 @@ stdout:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
+from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver
 from ansible.module_utils._text import to_native
 
 # ===========================================
@@ -86,9 +86,6 @@ def perform_checks(module):
         module.fail_json(
             msg="login_port must be a valid unix port number (0-65535)"
         )
-
-    if mysql_driver is None:
-        module.fail_json(msg=mysql_driver_fail_msg)
 
 
 def save_config_to_disk(variable, cursor):

--- a/plugins/modules/proxysql_manage_config.py
+++ b/plugins/modules/proxysql_manage_config.py
@@ -97,7 +97,7 @@ stdout:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
+from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver
 from ansible.module_utils._text import to_native
 
 # ===========================================

--- a/plugins/modules/proxysql_manage_config.py
+++ b/plugins/modules/proxysql_manage_config.py
@@ -134,9 +134,6 @@ def perform_checks(module):
                           " with the CONFIG config_layer")
             module.fail_json(msg=msg_string % module.params["direction"])
 
-    if mysql_driver is None:
-        module.fail_json(msg=mysql_driver_fail_msg)
-
 
 def manage_config(manage_config_settings, cursor):
 

--- a/plugins/modules/proxysql_mysql_users.py
+++ b/plugins/modules/proxysql_mysql_users.py
@@ -159,7 +159,7 @@ stdout:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
+from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native, to_bytes
 from hashlib import sha1
@@ -175,9 +175,6 @@ def perform_checks(module):
         module.fail_json(
             msg="login_port must be a valid unix port number (0-65535)"
         )
-
-    if mysql_driver is None:
-        module.fail_json(msg=mysql_driver_fail_msg)
 
 
 def save_config_to_disk(cursor):

--- a/plugins/modules/proxysql_query_rules.py
+++ b/plugins/modules/proxysql_query_rules.py
@@ -311,7 +311,7 @@ stdout:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
+from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
 
@@ -326,9 +326,6 @@ def perform_checks(module):
         module.fail_json(
             msg="login_port must be a valid unix port number (0-65535)"
         )
-
-    if mysql_driver is None:
-        module.fail_json(msg=mysql_driver_fail_msg)
 
 
 def save_config_to_disk(cursor):

--- a/plugins/modules/proxysql_query_rules_fast_routing.py
+++ b/plugins/modules/proxysql_query_rules_fast_routing.py
@@ -106,7 +106,7 @@ stdout:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
+from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
 
@@ -118,9 +118,6 @@ from ansible.module_utils._text import to_native
 def perform_checks(module):
     if module.params["login_port"] < 0 or module.params["login_port"] > 65535:
         module.fail_json(msg="login_port must be a valid unix port number (0-65535)")
-
-    if mysql_driver is None:
-        module.fail_json(msg=mysql_driver_fail_msg)
 
 
 def save_config_to_disk(cursor):

--- a/plugins/modules/proxysql_replication_hostgroups.py
+++ b/plugins/modules/proxysql_replication_hostgroups.py
@@ -96,7 +96,7 @@ stdout:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
+from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver
 from ansible.module_utils._text import to_native
 
 # ===========================================
@@ -127,9 +127,6 @@ def perform_checks(module):
         module.fail_json(
             msg="reader_hostgroup cannot equal writer_hostgroup"
         )
-
-    if mysql_driver is None:
-        module.fail_json(msg=mysql_driver_fail_msg)
 
 
 def save_config_to_disk(cursor):

--- a/plugins/modules/proxysql_scheduler.py
+++ b/plugins/modules/proxysql_scheduler.py
@@ -134,7 +134,7 @@ stdout:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
+from ansible_collections.community.proxysql.plugins.module_utils.mysql import mysql_connect, mysql_driver
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
 
@@ -155,9 +155,6 @@ def perform_checks(module):
         module.fail_json(
             msg="interval_ms must between 100ms & 100000000ms"
         )
-
-    if mysql_driver is None:
-        module.fail_json(msg=mysql_driver_fail_msg)
 
 
 def save_config_to_disk(cursor):


### PR DESCRIPTION
##### SUMMARY
Rework error handling when required libraries are missing using `from ansible.module_utils.basic import missing_required_lib`

closes #47 

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
Every module is affected in this collection

