### PR TITLE
Local integration test

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Set ProxySQL version (${{ matrix.proxysql }})
         run: "sed -i 's/^proxysql_version:.*/proxysql_version: \"${{ matrix.proxysql }}\"/g' ${{ env.proxysql_version_file }}"
 
+      - name: install python3-apt to detect of proxysql is already available
+        run: apt install python3-apt -y
+
       - name: Run integration tests
         run: ansible-test integration --docker -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --diff --coverage
         working-directory: ./ansible_collections/community/proxysql

--- a/tests/integration/targets/localhost.yml
+++ b/tests/integration/targets/localhost.yml
@@ -17,7 +17,7 @@
         auto_remove: yes
         recreate: yes
         container_default_behavior: no_defaults
-      
+
     - name: add proxysql container temporary host group testing
       add_host: hostname=proxysql groups=testing
 
@@ -40,7 +40,7 @@
     - name: install pymysql requirements in docker container
       when: "mysql_connector == 'pymysql'"
       apt:
-        name: 
+        name:
           - python3-pymysql
           - python3-apt
           - mysql-client
@@ -52,7 +52,7 @@
       block:
         - name: apt packages
           apt:
-            name: 
+            name:
               - python3-apt
               - mysql-client
               - python3-dev

--- a/tests/integration/targets/localhost.yml
+++ b/tests/integration/targets/localhost.yml
@@ -1,0 +1,92 @@
+---
+- name: >
+    start proxysql container
+    requires docker sdk and docker daemon
+    --extra-vars "PROXYSQL_VERSION=2.0.18"
+    --extra-vars "mysql_connector=mysqlclient"
+  hosts: localhost
+  connection: local
+
+  tasks:
+    - name: >
+        start proxysql container for integration tests
+      community.docker.docker_container:
+        name: proxysql
+        image: "proxysql/proxysql:{{ PROXYSQL_VERSION | default('2.2.0') }}"
+        state: started
+        auto_remove: yes
+        recreate: yes
+        container_default_behavior: no_defaults
+      
+    - name: add proxysql container temporary host group testing
+      add_host: hostname=proxysql groups=testing
+
+
+- name: >
+    prepare proxysql container
+    basically installing requirements that are missing
+    in the official proxysql base image
+    currently it based on debian stretch
+    run integration tests against local proxysql container
+    changes on modules must be build and installed with ansible-galaxy
+  hosts: testing
+  connection: docker
+
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+    mysql_connector: pymysql
+
+  tasks:
+    - name: install pymysql requirements in docker container
+      when: "mysql_connector == 'pymysql'"
+      apt:
+        name: 
+          - python3-pymysql
+          - python3-apt
+          - mysql-client
+        state: present
+        update_cache: yes
+
+    - name: install mysqlclient requirements in docker container
+      when: "mysql_connector == 'mysqlclient'"
+      block:
+        - name: apt packages
+          apt:
+            name: 
+              - python3-apt
+              - mysql-client
+              - python3-dev
+              - default-libmysqlclient-dev
+              - build-essential
+              - python3-pip
+            state: present
+            update_cache: yes
+
+        - name: install mysqlclient
+          pip:
+            name: mysqlclient
+
+    - name: include roles for integrationtest itself
+      include_role:
+        name: "{{ item }}"
+      with_items:
+        - test_proxysql_backend_servers
+        - test_proxysql_global_variables
+        - test_proxysql_mysql_users
+        - test_proxysql_query_rules
+        - test_proxysql_query_rules_fast_routing
+        - test_proxysql_replication_hostgroups
+        - test_proxysql_scheduler
+
+
+- name: >
+    stop docker container / clean up local environment
+  hosts: localhost
+  connection: local
+
+  tasks:
+    - name: stop proxysql container
+      community.docker.docker_container:
+        name: proxysql
+        state: stopped
+        container_default_behavior: no_defaults

--- a/tests/integration/targets/setup_proxysql/tasks/main.yml
+++ b/tests/integration/targets/setup_proxysql/tasks/main.yml
@@ -6,7 +6,6 @@
 - name: Gather the package facts
   ansible.builtin.package_facts:
     manager: apt
-  ignore_errors: yes
 
 - name: install and configure proxysql only if not exists
   when: ansible_facts.packages['proxysql'] is not defined

--- a/tests/integration/targets/setup_proxysql/tasks/main.yml
+++ b/tests/integration/targets/setup_proxysql/tasks/main.yml
@@ -3,6 +3,13 @@
 # WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+    manager: apt
+  ignore_errors: yes
 
-- import_tasks: install.yml
-- import_tasks: config.yml
+- name: install and configure proxysql only if not exists
+  when: ansible_facts.packages['proxysql'] is not defined
+  block:
+    - import_tasks: install.yml
+    - import_tasks: config.yml

--- a/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/base_test.yml
+++ b/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/base_test.yml
@@ -11,7 +11,7 @@
 ### when
 
 - name: "{{ role_name }} | {{ current_test }} | {{ test_delete|ternary('delete','create') }} test query rules fast routing"
-  proxysql_query_rules_fast_routing:
+  community.proxysql.proxysql_query_rules_fast_routing:
     login_user: admin
     login_password: admin
     username: '{{ test_user }}'


### PR DESCRIPTION
##### SUMMARY
* Add the ability to run integration tests locally.
* Fix one module task name in integration test


##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
None

##### ADDITIONAL INFORMATION

I added one playbook `localhost.yml` in `tests/integration/targets/`.  
Basically it is one playbook with three plays.

1. It starts a proxysql docker container locally.
2. two thinks happen in the 2nd play
    * It installs dependencies in the running container
    * It executes all integration test roles inside the container
3. It stops the container.

You can control different proxysql version and even change the mysql connector using `--extra-vars`  
Defaults are proxysql 2.2.0 and pymysql.

```
ansible-playbook localhost.yml --extra-vars "mysql_connector=mysqlclient PROXYSQL_VERSION=2.0.18"

...

PLAY RECAP **********************************************************************************************
localhost                  : ok=5    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
proxysql                   : ok=1424 changed=693  unreachable=0    failed=0    skipped=294  rescued=0    ignored=0 
``` 

**Requirements**

* python docker sdk
* docker daemon

**Advantage**

* It runs 1:1 the same roles like the integration test in github actions, but locally inside a docker container
* Just the setup role is modified, so it is only running, when proxysql is not already presented.

**Disadvantage**

* modifications that need to be tested locally must be build and installed using `ansible-galaxy` first, before apply the playbook
* It's kind of a hack/convention, because the integration tests does not run with `ansible-test integration`

