### PR TITLE
#61 refactor perform_checks function

### DIFF
--- a/changelogs/fragments/61-refactor-login-port-check.yml
+++ b/changelogs/fragments/61-refactor-login-port-check.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- refactor perform_checks function and move login_port check to module_utils/mysql.py (https://github.com/ansible-collections/community.proxysql/pull/61)

--- a/changelogs/fragments/61-refactor-login-port-check.yml
+++ b/changelogs/fragments/61-refactor-login-port-check.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- refactor perform_checks function and move login_port check to module_utils/mysql.py (https://github.com/ansible-collections/community.proxysql/pull/61)

--- a/changelogs/fragments/63-refactor-login-port-check.yml
+++ b/changelogs/fragments/63-refactor-login-port-check.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- refactor perform_checks function and move login_port check to module_utils/mysql.py (https://github.com/ansible-collections/community.proxysql/pull/63)

--- a/changelogs/fragments/63-refactor-login-port-check.yml
+++ b/changelogs/fragments/63-refactor-login-port-check.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- refactor perform_checks function and move login_port check to module_utils/mysql.py (https://github.com/ansible-collections/community.proxysql/pull/63)
+- refactor ``perform_checks`` function and move ``login_port`` check to ``module_utils/mysql.py`` (https://github.com/ansible-collections/community.proxysql/pull/63).

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -48,6 +48,12 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if not HAS_MYSQL_PACKAGE:
         module.fail_json(msg=missing_required_lib("pymysql or MySQLdb"), exception=MYSQL_IMP_ERR)
 
+    if module.params["login_port"] < 0 \
+       or module.params["login_port"] > 65535:
+        module.fail_json(
+            msg="login_port must be a valid unix port number (0-65535)"
+        )
+
     if config_file and os.path.exists(config_file):
         config['read_default_file'] = config_file
         cp = parse_from_mysql_config_file(config_file)

--- a/plugins/modules/proxysql_backend_servers.py
+++ b/plugins/modules/proxysql_backend_servers.py
@@ -169,7 +169,6 @@ from ansible.module_utils._text import to_native
 
 
 def perform_checks(module):
-
     if module.params["port"] < 0 \
        or module.params["port"] > 65535:
         module.fail_json(

--- a/plugins/modules/proxysql_backend_servers.py
+++ b/plugins/modules/proxysql_backend_servers.py
@@ -169,11 +169,6 @@ from ansible.module_utils._text import to_native
 
 
 def perform_checks(module):
-    if module.params["login_port"] < 0 \
-       or module.params["login_port"] > 65535:
-        module.fail_json(
-            msg="login_port must be a valid unix port number (0-65535)"
-        )
 
     if module.params["port"] < 0 \
        or module.params["port"] > 65535:

--- a/plugins/modules/proxysql_global_variables.py
+++ b/plugins/modules/proxysql_global_variables.py
@@ -81,14 +81,6 @@ from ansible.module_utils._text import to_native
 #
 
 
-def perform_checks(module):
-    if module.params["login_port"] < 0 \
-       or module.params["login_port"] > 65535:
-        module.fail_json(
-            msg="login_port must be a valid unix port number (0-65535)"
-        )
-
-
 def save_config_to_disk(variable, cursor):
     if variable.startswith("admin"):
         cursor.execute("SAVE ADMIN VARIABLES TO DISK")
@@ -185,8 +177,6 @@ def main():
         ),
         supports_check_mode=True
     )
-
-    perform_checks(module)
 
     login_user = module.params["login_user"]
     login_password = module.params["login_password"]

--- a/plugins/modules/proxysql_manage_config.py
+++ b/plugins/modules/proxysql_manage_config.py
@@ -107,11 +107,6 @@ from ansible.module_utils._text import to_native
 
 
 def perform_checks(module):
-    if module.params["login_port"] < 0 \
-       or module.params["login_port"] > 65535:
-        module.fail_json(
-            msg="login_port must be a valid unix port number (0-65535)"
-        )
 
     if module.params["config_layer"] == 'CONFIG' and \
             (module.params["action"] != 'LOAD' or

--- a/plugins/modules/proxysql_manage_config.py
+++ b/plugins/modules/proxysql_manage_config.py
@@ -107,7 +107,6 @@ from ansible.module_utils._text import to_native
 
 
 def perform_checks(module):
-
     if module.params["config_layer"] == 'CONFIG' and \
             (module.params["action"] != 'LOAD' or
              module.params["direction"] != 'FROM'):

--- a/plugins/modules/proxysql_mysql_users.py
+++ b/plugins/modules/proxysql_mysql_users.py
@@ -170,14 +170,6 @@ from hashlib import sha1
 #
 
 
-def perform_checks(module):
-    if module.params["login_port"] < 0 \
-       or module.params["login_port"] > 65535:
-        module.fail_json(
-            msg="login_port must be a valid unix port number (0-65535)"
-        )
-
-
 def save_config_to_disk(cursor):
     cursor.execute("SAVE MYSQL USERS TO DISK")
     return True
@@ -444,8 +436,6 @@ def main():
         ),
         supports_check_mode=True
     )
-
-    perform_checks(module)
 
     login_user = module.params["login_user"]
     login_password = module.params["login_password"]

--- a/plugins/modules/proxysql_query_rules.py
+++ b/plugins/modules/proxysql_query_rules.py
@@ -321,14 +321,6 @@ from ansible.module_utils._text import to_native
 #
 
 
-def perform_checks(module):
-    if module.params["login_port"] < 0 \
-       or module.params["login_port"] > 65535:
-        module.fail_json(
-            msg="login_port must be a valid unix port number (0-65535)"
-        )
-
-
 def save_config_to_disk(cursor):
     cursor.execute("SAVE MYSQL QUERY RULES TO DISK")
     return True
@@ -623,8 +615,6 @@ def main():
         ),
         supports_check_mode=True
     )
-
-    perform_checks(module)
 
     login_user = module.params["login_user"]
     login_password = module.params["login_password"]

--- a/plugins/modules/proxysql_query_rules_fast_routing.py
+++ b/plugins/modules/proxysql_query_rules_fast_routing.py
@@ -116,11 +116,6 @@ from ansible.module_utils._text import to_native
 #
 
 
-def perform_checks(module):
-    if module.params["login_port"] < 0 or module.params["login_port"] > 65535:
-        module.fail_json(msg="login_port must be a valid unix port number (0-65535)")
-
-
 def save_config_to_disk(cursor):
     cursor.execute("SAVE MYSQL QUERY RULES TO DISK")
     return True
@@ -365,8 +360,6 @@ def main():
         ),
         supports_check_mode=True
     )
-
-    perform_checks(module)
 
     login_user = module.params["login_user"]
     login_password = module.params["login_password"]

--- a/plugins/modules/proxysql_replication_hostgroups.py
+++ b/plugins/modules/proxysql_replication_hostgroups.py
@@ -106,11 +106,6 @@ from ansible.module_utils._text import to_native
 
 
 def perform_checks(module):
-    if module.params["login_port"] < 0 \
-       or module.params["login_port"] > 65535:
-        module.fail_json(
-            msg="login_port must be a valid unix port number (0-65535)"
-        )
 
     if not module.params["writer_hostgroup"] >= 0:
         module.fail_json(

--- a/plugins/modules/proxysql_replication_hostgroups.py
+++ b/plugins/modules/proxysql_replication_hostgroups.py
@@ -106,7 +106,6 @@ from ansible.module_utils._text import to_native
 
 
 def perform_checks(module):
-
     if not module.params["writer_hostgroup"] >= 0:
         module.fail_json(
             msg="writer_hostgroup must be a integer greater than or equal to 0"

--- a/plugins/modules/proxysql_scheduler.py
+++ b/plugins/modules/proxysql_scheduler.py
@@ -145,11 +145,6 @@ from ansible.module_utils._text import to_native
 
 
 def perform_checks(module):
-    if module.params["login_port"] < 0 \
-       or module.params["login_port"] > 65535:
-        module.fail_json(
-            msg="login_port must be a valid unix port number (0-65535)"
-        )
 
     if module.params["interval_ms"] < 100 \
        or module.params["interval_ms"] > 100000000:

--- a/plugins/modules/proxysql_scheduler.py
+++ b/plugins/modules/proxysql_scheduler.py
@@ -145,7 +145,6 @@ from ansible.module_utils._text import to_native
 
 
 def perform_checks(module):
-
     if module.params["interval_ms"] < 100 \
        or module.params["interval_ms"] > 100000000:
         module.fail_json(


### PR DESCRIPTION
##### SUMMARY
closes #61

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
proxysql_backend_servers  
proxysql_global_variables  
proxysql_manage_config  
proxysql_mysql_user  
proxysql_query_rules  
proxysql_query_rules_fast_routing   
proxysql_replication_hostgroups  
proxysql_scheduler


##### ADDITIONAL INFORMATION

* `login_port` check is moved for all modules to `plugins/module_utils/mysql.py`  
* modules that only verify `login_port` in their `perform_checks()` function, does not have a `perform_checks()` function anymore.
