### PR TITLE
Add support for next_query_flagIN

### DIFF
--- a/changelogs/fragments/74-add-support-for-next_query_flagIN.yml
+++ b/changelogs/fragments/74-add-support-for-next_query_flagIN.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- proxysql_query_rules - add ``next_query_flagIN`` argument (https://github.com/ansible-collections/community.proxysql/pull/74).

--- a/plugins/modules/proxysql_query_rules.py
+++ b/plugins/modules/proxysql_query_rules.py
@@ -270,29 +270,29 @@ EXAMPLES = '''
 # and avoid replication lag
 
 - name: Add insert query rule
-   proxysql_query_rules:
-      match_digest: "^INSERT"
-      destination_hostgroup: 1,
-      next_query_flagIN: 1
+  proxysql_query_rules:
+    match_digest: "^INSERT"
+    destination_hostgroup: 1,
+    next_query_flagIN: 1
 
 - name: Add update query rule
-   proxysql_query_rules:
-      match_digest: "^UPDATE"
-      destination_hostgroup: 1,
-      next_query_flagIN: 1
+  proxysql_query_rules:
+    match_digest: "^UPDATE"
+    destination_hostgroup: 1,
+    next_query_flagIN: 1
 
 - name: Add delete query rules
-   proxysql_query_rules:
-      match_digest: "^DELETE"
-      destination_hostgroup: 1,
-      next_query_flagIN: 1
+  proxysql_query_rules:
+    match_digest: "^DELETE"
+    destination_hostgroup: 1,
+    next_query_flagIN: 1
 
 - name: Add insert query rules
-   proxysql_query_rules:
-      match_digest: ".*"
-      destination_hostgroup: 1,
-      next_query_flagIN: 1
-      comment: Match every queries after an INSERT/UPDATE/DELETE query
+  proxysql_query_rules:
+    match_digest: ".*"
+    destination_hostgroup: 1,
+    next_query_flagIN: 1
+    comment: Match every queries after an INSERT/UPDATE/DELETE query
 
 # This example removes all rules that use the username 'guest_ro', saves the
 # mysql query rule config to disk, and dynamically loads the mysql query rule

--- a/plugins/modules/proxysql_query_rules.py
+++ b/plugins/modules/proxysql_query_rules.py
@@ -142,7 +142,8 @@ options:
   next_query_flagIN:
     description:
       - When is set, its value will become the I(flagIN) value for the next queries.
-    version_added: "2.9"
+    type: int
+    version_added: "1.3.0"
   mirror_flagOUT:
     description:
       - Enables query mirroring. If set I(mirror_flagOUT) can be used to

--- a/plugins/modules/proxysql_query_rules.py
+++ b/plugins/modules/proxysql_query_rules.py
@@ -81,7 +81,8 @@ options:
         With C(CASELESS) the match is case insensitive. With C(GLOBAL) the replace
         is global (replaces all matches and not just the first).
         For backward compatibility, only C(CASELESS) is the enabled by default.
-    version_added: "2.9"
+    type: str
+    version_added: "1.3.0"
   flagOUT:
     description:
       - Used in combination with I(flagIN) and apply to create chains of rules.

--- a/plugins/modules/proxysql_query_rules.py
+++ b/plugins/modules/proxysql_query_rules.py
@@ -75,6 +75,13 @@ options:
         operator in front of the regular expression matching against
         match_pattern.
     type: bool
+  re_modifiers:
+    description:
+      - Comma separated list of options to modify the behavior of the RE engine.
+        With C(CASELESS) the match is case insensitive. With C(GLOBAL) the replace
+        is global (replaces all matches and not just the first).
+        For backward compatibility, only C(CASELESS) is the enabled by default.
+    version_added: "2.9"
   flagOUT:
     description:
       - Used in combination with I(flagIN) and apply to create chains of rules.
@@ -132,6 +139,10 @@ options:
         priority to queries over others. This value is added to the
         mysql-default_query_delay global variable that applies to all queries.
     type: int
+  next_query_flagIN:
+    description:
+      - When is set, its value will become the I(flagIN) value for the next queries.
+    version_added: "2.9"
   mirror_flagOUT:
     description:
       - Enables query mirroring. If set I(mirror_flagOUT) can be used to
@@ -355,6 +366,7 @@ class ProxyQueryRule(object):
                             "match_digest",
                             "match_pattern",
                             "negate_match_pattern",
+                            "re_modifiers",
                             "flagOUT",
                             "replace_pattern",
                             "destination_hostgroup",
@@ -364,10 +376,12 @@ class ProxyQueryRule(object):
                             "timeout",
                             "retries",
                             "delay",
+                            "next_query_flagIN",
                             "mirror_flagOUT",
                             "mirror_hostgroup",
-                            "OK_msg",
                             "error_msg",
+                            "OK_msg",
+                            "multiplex",
                             "log",
                             "apply",
                             "comment"]
@@ -589,6 +603,7 @@ def main():
         match_digest=dict(type='str'),
         match_pattern=dict(type='str'),
         negate_match_pattern=dict(type='bool'),
+        re_modifiers=dict(type='str'),
         flagOUT=dict(type='int'),
         replace_pattern=dict(type='str'),
         destination_hostgroup=dict(type='int'),
@@ -598,6 +613,7 @@ def main():
         timeout=dict(type='int'),
         retries=dict(type='int'),
         delay=dict(type='int'),
+        next_query_flagIN=dict(type='int'),
         mirror_flagOUT=dict(type='int'),
         mirror_hostgroup=dict(type='int'),
         OK_msg=dict(type='str'),

--- a/plugins/modules/proxysql_query_rules.py
+++ b/plugins/modules/proxysql_query_rules.py
@@ -265,7 +265,7 @@ EXAMPLES = '''
     multiplex: 2
 
 # This example demonstrates how to use next_query_flagIN argument. It allows
-# ProxySQL query rules to be chained. The examples shows how you can have SELECTS 
+# ProxySQL query rules to be chained. The examples shows how you can have SELECTS
 # immediately follow INSERT/UPDATE/DELETE statements to query the primary hostgroup
 # and avoid replication lag
 

--- a/plugins/modules/proxysql_query_rules.py
+++ b/plugins/modules/proxysql_query_rules.py
@@ -264,6 +264,36 @@ EXAMPLES = '''
     match_digest: '^SELECT @@max_allowed_packet'
     multiplex: 2
 
+# This example demonstrates how to use next_query_flagIN argument. It allows
+# ProxySQL query rules to be chained. The examples shows how you can have SELECTS 
+# immediately follow INSERT/UPDATE/DELETE statements to query the primary hostgroup
+# and avoid replication lag
+
+- name: Add insert query rule
+   proxysql_query_rules:
+      match_digest: "^INSERT"
+      destination_hostgroup: 1,
+      next_query_flagIN: 1
+
+- name: Add update query rule
+   proxysql_query_rules:
+      match_digest: "^UPDATE"
+      destination_hostgroup: 1,
+      next_query_flagIN: 1
+
+- name: Add delete query rules
+   proxysql_query_rules:
+      match_digest: "^DELETE"
+      destination_hostgroup: 1,
+      next_query_flagIN: 1
+
+- name: Add insert query rules
+   proxysql_query_rules:
+      match_digest: ".*"
+      destination_hostgroup: 1,
+      next_query_flagIN: 1
+      comment: Match every queries after an INSERT/UPDATE/DELETE query
+
 # This example removes all rules that use the username 'guest_ro', saves the
 # mysql query rule config to disk, and dynamically loads the mysql query rule
 # config to runtime.  It uses credentials in a supplied config file to connect
@@ -350,7 +380,7 @@ def load_config_to_runtime(cursor):
 
 class ProxyQueryRule(object):
 
-    def __init__(self, module, version):
+    def __init__(self, module):
         self.state = module.params["state"]
         self.force_delete = module.params["force_delete"]
         self.save_to_disk = module.params["save_to_disk"]
@@ -373,10 +403,12 @@ class ProxyQueryRule(object):
                             "replace_pattern",
                             "destination_hostgroup",
                             "cache_ttl",
+                            "cache_empty_result",
                             "multiplex",
                             "timeout",
                             "retries",
                             "delay",
+                            "next_query_flagIN",
                             "mirror_flagOUT",
                             "mirror_hostgroup",
                             "error_msg",
@@ -385,11 +417,6 @@ class ProxyQueryRule(object):
                             "log",
                             "apply",
                             "comment"]
-
-        if version.get('major') >= 2:
-            config_data_keys.append([
-              "cache_empty_result",
-              "next_query_flagIN"])                            
 
         self.config_data = dict((k, module.params[k])
                                 for k in config_data_keys)
@@ -654,7 +681,7 @@ def main():
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)
         )
 
-    proxysql_query_rule = ProxyQueryRule(module, version)
+    proxysql_query_rule = ProxyQueryRule(module)
     result = {}
 
     result['state'] = proxysql_query_rule.state

--- a/plugins/modules/proxysql_query_rules.py
+++ b/plugins/modules/proxysql_query_rules.py
@@ -350,7 +350,7 @@ def load_config_to_runtime(cursor):
 
 class ProxyQueryRule(object):
 
-    def __init__(self, module):
+    def __init__(self, module, version):
         self.state = module.params["state"]
         self.force_delete = module.params["force_delete"]
         self.save_to_disk = module.params["save_to_disk"]
@@ -373,12 +373,10 @@ class ProxyQueryRule(object):
                             "replace_pattern",
                             "destination_hostgroup",
                             "cache_ttl",
-                            "cache_empty_result",
                             "multiplex",
                             "timeout",
                             "retries",
                             "delay",
-                            "next_query_flagIN",
                             "mirror_flagOUT",
                             "mirror_hostgroup",
                             "error_msg",
@@ -387,6 +385,11 @@ class ProxyQueryRule(object):
                             "log",
                             "apply",
                             "comment"]
+
+        if version.get('major') >= 2:
+            config_data_keys.append([
+              "cache_empty_result",
+              "next_query_flagIN"])                            
 
         self.config_data = dict((k, module.params[k])
                                 for k in config_data_keys)
@@ -651,7 +654,7 @@ def main():
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)
         )
 
-    proxysql_query_rule = ProxyQueryRule(module)
+    proxysql_query_rule = ProxyQueryRule(module, version)
     result = {}
 
     result['state'] = proxysql_query_rule.state

--- a/tests/integration/targets/test_proxysql_query_rules/defaults/main.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/defaults/main.yml
@@ -7,6 +7,7 @@ test_retries: 3
 test_cache_ttl: 20000
 test_cache_empty_result: 0
 test_multiplex: 0
+test_next_query_flagin: 0
 
 test_proxysql_query_rules_check_mode: false
 test_proxysql_query_rules_in_memory_only: false

--- a/tests/integration/targets/test_proxysql_query_rules/tasks/base_test.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/tasks/base_test.yml
@@ -22,6 +22,7 @@
     cache_ttl: '{{ test_cache_ttl }}'
     cache_empty_result: '{{ test_cache_empty_result }}'
     multiplex: '{{ test_multiplex }}'
+    next_query_flagIN: '{{ test_next_query_flagin }}'
     state: "{{ test_delete|ternary('absent', 'present') }}"
     save_to_disk: "{{ not test_proxysql_query_rules_in_memory_only }}"
     load_to_runtime: "{{ not test_proxysql_query_rules_in_memory_only }}"
@@ -52,13 +53,13 @@
   when: test_proxysql_query_rules_with_delayed_persist
 
 - name: "{{ role_name }} | {{ current_test }} | check if test query rule exists in memory"
-  shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"SELECT username || ',' || match_pattern || ',' || destination_hostgroup || ',' || active || ',' || retries || ',' || cache_ttl || ',' || cache_empty_result || ',' || multiplex FROM mysql_query_rules where username = '{{ test_user }}' and match_pattern = '{{ test_match_pattern }}' and destination_hostgroup and '{{ test_destination_hostgroup }}' and active = '{{ test_active }}' and retries = '{{ test_retries }}' and cache_ttl = '{{ test_cache_ttl }}' and cache_empty_result = '{{ test_cache_empty_result }}' and multiplex = '{{ test_multiplex }}'"
+  shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"SELECT username || ',' || match_pattern || ',' || destination_hostgroup || ',' || active || ',' || retries || ',' || cache_ttl || ',' || cache_empty_result || ',' || multiplex || ',' || next_query_flagIN FROM mysql_query_rules where username = '{{ test_user }}' and match_pattern = '{{ test_match_pattern }}' and destination_hostgroup and '{{ test_destination_hostgroup }}' and active = '{{ test_active }}' and retries = '{{ test_retries }}' and cache_ttl = '{{ test_cache_ttl }}' and cache_empty_result = '{{ test_cache_empty_result }}' and multiplex = '{{ test_multiplex }}' and next_query_flagIN = '{{ test_next_query_flagin }}'"
   register: memory_result
 
 - name: "{{ role_name }} | {{ current_test }} | check if test query rule exists on disk"
-  shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"SELECT username || ',' || match_pattern || ',' || destination_hostgroup || ',' || active || ',' || retries || ',' || cache_ttl || ',' || cache_empty_result || ',' || multiplex FROM disk.mysql_query_rules where username = '{{ test_user }}' and match_pattern = '{{ test_match_pattern }}' and destination_hostgroup and '{{ test_destination_hostgroup }}' and active = '{{ test_active }}' and retries = '{{ test_retries }}' and cache_ttl = '{{ test_cache_ttl }}' and cache_empty_result = '{{ test_cache_empty_result }}' and multiplex = '{{ test_multiplex }}'"
+  shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"SELECT username || ',' || match_pattern || ',' || destination_hostgroup || ',' || active || ',' || retries || ',' || cache_ttl || ',' || cache_empty_result || ',' || multiplex || ',' || next_query_flagIN FROM disk.mysql_query_rules where username = '{{ test_user }}' and match_pattern = '{{ test_match_pattern }}' and destination_hostgroup and '{{ test_destination_hostgroup }}' and active = '{{ test_active }}' and retries = '{{ test_retries }}' and cache_ttl = '{{ test_cache_ttl }}' and cache_empty_result = '{{ test_cache_empty_result }}' and multiplex = '{{ test_multiplex }}' and next_query_flagIN = '{{ test_next_query_flagin }}'"
   register: disk_result
 
 - name: "{{ role_name }} | {{ current_test }} | check if test query rule exists in runtime"
-  shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"SELECT username || ',' || match_pattern || ',' || destination_hostgroup || ',' || active || ',' || retries || ',' || cache_ttl || ',' || cache_empty_result || ',' || multiplex FROM runtime_mysql_query_rules where username = '{{ test_user }}' and match_pattern = '{{ test_match_pattern }}' and destination_hostgroup and '{{ test_destination_hostgroup }}' and active = '{{ test_active }}' and retries = '{{ test_retries }}' and cache_ttl = '{{ test_cache_ttl }}' and cache_empty_result = '{{ test_cache_empty_result }}' and multiplex = '{{ test_multiplex }}'"
+  shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"SELECT username || ',' || match_pattern || ',' || destination_hostgroup || ',' || active || ',' || retries || ',' || cache_ttl || ',' || cache_empty_result || ',' || multiplex || ',' || next_query_flagIN FROM runtime_mysql_query_rules where username = '{{ test_user }}' and match_pattern = '{{ test_match_pattern }}' and destination_hostgroup and '{{ test_destination_hostgroup }}' and active = '{{ test_active }}' and retries = '{{ test_retries }}' and cache_ttl = '{{ test_cache_ttl }}' and cache_empty_result = '{{ test_cache_empty_result }}' and multiplex = '{{ test_multiplex }}' and next_query_flagIN = '{{ test_next_query_flagin }}'"
   register: runtime_result

--- a/tests/integration/targets/test_proxysql_query_rules/tasks/setup_test_query_rule.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/tasks/setup_test_query_rule.yml
@@ -3,7 +3,7 @@
   block:
 
     - name: "{{ role_name }} | {{ current_test }}  | ensure test query rule is created in memory"
-      shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"INSERT OR REPLACE INTO mysql_query_rules (username, match_pattern, destination_hostgroup, active, retries, cache_ttl, cache_empty_result, multiplex) VALUES ('{{ test_user }}', '{{ test_match_pattern}}', '{{ test_destination_hostgroup }}', '{{ test_active }}', '{{ test_retries }}', '{{ test_cache_ttl }}', '{{ test_cache_empty_result }}', '{{ test_multiplex }}')"
+      shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"INSERT OR REPLACE INTO mysql_query_rules (username, match_pattern, destination_hostgroup, active, retries, cache_ttl, cache_empty_result, multiplex, next_query_flagIN) VALUES ('{{ test_user }}', '{{ test_match_pattern}}', '{{ test_destination_hostgroup }}', '{{ test_active }}', '{{ test_retries }}', '{{ test_cache_ttl }}', '{{ test_cache_empty_result }}', '{{ test_multiplex }}', '{{ test_next_query_flagin }}')"
 
     - name: "{{ role_name }} | {{ current_test }}  | ensure test query rule is created on disk"
       shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"SAVE MYSQL QUERY RULES TO DISK"

--- a/tests/integration/targets/test_proxysql_query_rules/tasks/test_create_query_rule.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/tasks/test_create_query_rule.yml
@@ -14,15 +14,15 @@
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create query rule did make a change in memory"
   assert:
-    that: memory_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }}'
+    that: memory_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }},{{ test_next_query_flagin }}'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create query rule did make a change on disk"
   assert:
-    that: disk_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }}'
+    that: disk_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }},{{ test_next_query_flagin }}'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create query rule did make a change to runtime"
   assert:
-    that: runtime_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }}'
+    that: runtime_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }},{{ test_next_query_flagin }}'
 
 ### perform cleanup
 

--- a/tests/integration/targets/test_proxysql_query_rules/tasks/test_create_query_rule_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/tasks/test_create_query_rule_in_memory_only.yml
@@ -14,7 +14,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create query rule did make a change in memory"
   assert:
-    that: memory_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }}'
+    that: memory_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }},{{ test_next_query_flagin }}'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create query rule didn't make a change on disk"
   assert:

--- a/tests/integration/targets/test_proxysql_query_rules/tasks/test_create_query_rule_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/tasks/test_create_query_rule_with_delayed_persist.yml
@@ -14,15 +14,15 @@
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create query rule did make a change in memory"
   assert:
-    that: memory_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }}'
+    that: memory_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }},{{ test_next_query_flagin }}'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create query rule did make a change on disk"
   assert:
-    that: disk_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }}'
+    that: disk_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }},{{ test_next_query_flagin }}'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create query rule did make a change to runtime"
   assert:
-    that: runtime_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }}'
+    that: runtime_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }},{{ test_next_query_flagin }}'
 
 ### perform cleanup
 

--- a/tests/integration/targets/test_proxysql_query_rules/tasks/test_delete_query_rule_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/tasks/test_delete_query_rule_in_memory_only.yml
@@ -18,11 +18,11 @@
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete query rule did make a change on disk"
   assert:
-    that: disk_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }}'
+    that: disk_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }},{{ test_next_query_flagin }}'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete query rule did make a change to runtime"
   assert:
-    that: runtime_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }}'
+    that: runtime_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }},{{ test_next_query_flagin }}'
 ### perform cleanup
 
 - name: "{{ role_name }} | {{ current_test }} | ensure we're in a clean state when we finish"

--- a/tests/integration/targets/test_proxysql_query_rules/tasks/test_delete_using_check_mode.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/tasks/test_delete_using_check_mode.yml
@@ -14,15 +14,15 @@
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete query rule in check mode didn't make a change in memory"
   assert:
-    that: memory_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }}'
+    that: memory_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }},{{ test_next_query_flagin }}'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete query rule in check mode didn't make a change on disk"
   assert:
-    that: disk_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }}'
+    that: disk_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }},{{ test_next_query_flagin }}'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete query rule in check mode didn't make a change to runtime"
   assert:
-    that: runtime_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }}'
+    that: runtime_result.stdout == '{{ test_user }},{{ test_match_pattern }},{{ test_destination_hostgroup }},{{ test_active }},{{ test_retries }},{{ test_cache_ttl }},{{ test_cache_empty_result }},{{ test_multiplex }},{{ test_next_query_flagin }}'
 
 ### perform cleanup
 


### PR DESCRIPTION
##### SUMMARY
This PR adds support for `next_query_flagIN` in the proxysql_query_rules plugin

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`proxysql_query_rules`

##### ADDITIONAL INFORMATION
`next_query_flagIN` allows to chain query rules which is useful for when example you want to allow a SELECT after an INSERT/UPDATE/DELETE to run on the same hostgroup (avoiding replication lag).

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Add insert query rule
   proxysql_query_rules:
      match_digest: "^INSERT"
      destination_hostgroup: 1,
      next_query_flagIN: 1

- name: Add update query rule
   proxysql_query_rules:
      match_digest: "^UPDATE"
      destination_hostgroup: 1,
      next_query_flagIN: 1

- name: Add delete query rules
   proxysql_query_rules:
      match_digest: "^DELETE"
      destination_hostgroup: 1,
      next_query_flagIN: 1

- name: Add insert query rules
   proxysql_query_rules:
      match_digest: ".*"
      destination_hostgroup: 1,
      next_query_flagIN: 1
      comment: Match every queries after an INSERT/UPDATE/DELETE query
```
