### PR TITLE
update proxysql version

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         proxysql:
-          - 2.0.12
+          - 2.3.2
         ansible:
           - stable-2.9
           - stable-2.10


### PR DESCRIPTION
##### SUMMARY
nightly ci pipeline is regulary failing


https://github.com/ansible-collections/community.proxysql/runs/4186701842?check_suite_focus=true

> "msg": "Failure downloading https://github.com/sysown/proxysql/releases/download/v2.0.12/proxysql_2.0.12-ubuntu20_amd64.deb, HTTP Error 404: Not Found"

`ansible-devel` has moved from ubuntu 18.04 to ubuntu 20.04. But proxysql 2.0.12 was not build/available for ubuntu 20.04.  
Therefore we're updating the pipeline to use the latest proxysql release 2.3.2