### PR TITLE
surpress no_log warning

### DIFF
--- a/changelogs/fragments/86-missing-no-log.yml
+++ b/changelogs/fragments/86-missing-no-log.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxysql_mysql_users - Add missing ``no_log`` option to ``encrypt_password`` parameter (https://github.com/ansible-collections/community.proxysql/pull/86).

--- a/plugins/modules/proxysql_mysql_users.py
+++ b/plugins/modules/proxysql_mysql_users.py
@@ -408,7 +408,7 @@ def main():
     argument_spec.update(
         username=dict(required=True, type='str'),
         password=dict(no_log=True, type='str'),
-        encrypt_password=dict(default=False, type='bool'),
+        encrypt_password=dict(default=False, type='bool', no_log=False),
         encryption_method=dict(default='mysql_native_password', choices=list(encryption_method_map.keys())),
         active=dict(type='bool'),
         use_ssl=dict(type='bool'),


### PR DESCRIPTION
##### SUMMARY

boolean parameter `encrypt_password` did not set `no_log`.

```
changed: [proxysql-latest] => (item={'user': 'some', 'password': 'mysecretpassword', 'default_hostgroup': 10, 'host_group': 'rds', 'database': 'some'})
[WARNING]: Module did not set no_log for encrypt_password
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
proxysql_mysql_user

##### ADDITIONAL INFORMATION

