### PR TITLE
#93 fix suffix parsing

### DIFF
--- a/changelogs/fragments/96-version-suffix-may-not-be-an-integer.yml
+++ b/changelogs/fragments/96-version-suffix-may-not-be-an-integer.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mysql.py - Proxysql version suffix may not be an integer (https://github.com/ansible-collections/community.proxysql/pull/96).

--- a/changelogs/fragments/96-version-suffix-may-not-be-an-integer.yml
+++ b/changelogs/fragments/96-version-suffix-may-not-be-an-integer.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - mysql.py - Proxysql version suffix may not be an integer (https://github.com/ansible-collections/community.proxysql/pull/96).
+  - module_utils/mysql.py - Proxysql version suffix may not be an integer (https://github.com/ansible-collections/community.proxysql/pull/96).

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -45,7 +45,8 @@ def _version(cursor):
     res = cursor.fetchone()
 
     # 2.2.0-72-ge14accd
-    raw_version = res.get('version()').split('-')
+    # 2.3.2-percona-1.1
+    raw_version = res.get('version()').split('-', 1)
     _version = raw_version[0].split('.')
 
     version = dict()
@@ -53,7 +54,7 @@ def _version(cursor):
     version['major'] = int(_version[0])
     version['minor'] = int(_version[1])
     version['release'] = int(_version[2])
-    version['suffix'] = int(raw_version[1])
+    version['suffix'] = raw_version[1]
 
     return version
 


### PR DESCRIPTION
##### SUMMARY
Closes https://github.com/ansible-collections/community.proxysql/issues/93

Fixes suffix parsing. Depending on the proxysql distribution, the suffix may not be an integer

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/module_utils/mysql.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
