### PR TITLE
backport-1: fix suffix parsing (#96)

### DIFF
--- a/changelogs/fragments/96-version-suffix-may-not-be-an-integer.yml
+++ b/changelogs/fragments/96-version-suffix-may-not-be-an-integer.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_utils/mysql.py - Proxysql version suffix may not be an integer (https://github.com/ansible-collections/community.proxysql/pull/96).

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -45,7 +45,8 @@ def _version(cursor):
     res = cursor.fetchone()
 
     # 2.2.0-72-ge14accd
-    raw_version = res.get('version()').split('-')
+    # 2.3.2-percona-1.1
+    raw_version = res.get('version()').split('-', 1)
     _version = raw_version[0].split('.')
 
     version = dict()
@@ -53,7 +54,7 @@ def _version(cursor):
     version['major'] = int(_version[0])
     version['minor'] = int(_version[1])
     version['release'] = int(_version[2])
-    version['suffix'] = int(raw_version[1])
+    version['suffix'] = raw_version[1]
 
     return version
 


### PR DESCRIPTION
Backport of https://github.com/ansible-collections/community.proxysql/pull/96 to stable-1 (_based on 1.3.1_) to prepare 1.3.2 later.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/mysql.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
