### PR TITLE
Drop support for Ansible 2.9 and ansible-base 2.10

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -24,8 +24,6 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.9
-          - stable-2.10
           - stable-2.11
           - stable-2.12
           - stable-2.13
@@ -58,8 +56,6 @@ jobs:
         proxysql:
           - 2.3.2
         ansible:
-          - stable-2.9
-          - stable-2.10
           - stable-2.11
           - stable-2.12
           - stable-2.13

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ For more information about communication, refer to the [Ansible Communication gu
 
 Note: if you do not see documentation for a module on [docs.ansible.come](https://docs.ansible.com/ansible/devel/collections/community/proxysql/), use the [ansible-doc](https://docs.ansible.com/ansible/latest/cli/ansible-doc.html) command or see the `DOCUMENTATION` section in the `plugins/modules/<module_name>.py` file.
 
-## Tested with Ansible
+## Supports and tested with ansible-core
 
-- 2.9
-- 2.10
 - 2.11
-- devel
+- 2.12
+- 2.13
+- current development version
 
 ## External requirements
 


### PR DESCRIPTION
##### SUMMARY
Drop support for Ansible 2.9 and ansible-base 2.10 because they'll get EOL in May 2022

Fyi: we still have 2.9 for role testing matrix (only 2.9 due to technical issues as described in .github/workflows/ansible-test-roles.yml