### PR TITLE
backport-1: Fix removed client_found_rows mysql variable (#101)

### DIFF
--- a/changelogs/fragments/101-removed-mysql-variable.yml
+++ b/changelogs/fragments/101-removed-mysql-variable.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - roles/proxysql - As of ProxySQL 2.4.0, `client_found_rows` mysql variable has been removed (https://github.com/ansible-collections/community.proxysql/pull/101).

--- a/roles/proxysql/vars/main.yml
+++ b/roles/proxysql/vars/main.yml
@@ -104,16 +104,13 @@ proxysql_admin_variables:
     variable: "web_port"
     variable_value: "{{ proxysql_admin_web_port }}"
 
-proxysql_mysql_variables:
+_proxysql_mysql_variables:
   autocommit_false_is_transaction:
     variable: "autocommit_false_is_transaction"
     variable_value: "{{ proxysql_mysql_autocommit_false_is_transaction | to_json }}"
   autocommit_false_not_reusable:
     variable: "autocommit_false_not_reusable"
     variable_value: "{{ proxysql_mysql_autocommit_false_not_reusable | to_json }}"
-  client_found_rows:
-    variable: "client_found_rows"
-    variable_value: "{{ proxysql_mysql_client_found_rows | to_json }}"
   commands_stats:
     variable: "commands_stats"
     variable_value: "{{ proxysql_mysql_commands_stats | to_json }}"
@@ -375,6 +372,13 @@ proxysql_mysql_variables:
   wait_timeout:
     variable: "wait_timeout"
     variable_value: "{{ proxysql_mysql_mysql_wait_timeout }}"
+
+_proxysql_mysql_client_found_rows:
+  client_found_rows:
+    variable: "client_found_rows"
+    variable_value: "{{ proxysql_mysql_client_found_rows | to_json }}"
+
+proxysql_mysql_variables: "{{ _proxysql_mysql_variables | combine((proxysql_version is version('2.4.0', '<')) | ternary(_proxysql_mysql_client_found_rows, {})) }}"
 
 proxysql_mysql_options:
   mysql_threads:


### PR DESCRIPTION
backport #101 to stable-1

---

* Fix removed client_found_rows mysql variable

As of ProxySQL 2.4.0, client_found_rows variable has been removed.
SEE: https://github.com/sysown/proxysql/commit/02915a9eae20ee32555922fcb046403852e1f923

* Add changelog fragment
