### PR TITLE
Fix missing host parameter for wait_for module

### DIFF
--- a/changelogs/fragments/115-wait-for-fix.yml
+++ b/changelogs/fragments/115-wait-for-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - roles/proxysql - Fix wait_for task when `proxysql_admin_bind_address` is overridden (https://github.com/ansible-collections/community.proxysql/pull/115).

--- a/roles/proxysql/tasks/config.yml
+++ b/roles/proxysql/tasks/config.yml
@@ -24,6 +24,7 @@
 
 - name: proxysql | config | wait for proxysql
   wait_for:
+    host: "{{ proxysql_admin_bind_address }}"
     port: "{{ proxysql_admin_port }}"
     state: started
     timeout: 30


### PR DESCRIPTION
##### SUMMARY
In cases where `proxysql_admin_bind_address` is overridden, the wait_for tasks were failing

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxysql role

