### PR TITLE
Fix missing proxysql_global_variables parameters

### DIFF
--- a/changelogs/fragments/116-proxysql-global-variables-parameters.yml
+++ b/changelogs/fragments/116-proxysql-global-variables-parameters.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - roles/proxysql - Missing proxysql_global_variables module parameters (https://github.com/ansible-collections/community.proxysql/pull/116).

--- a/roles/proxysql/handlers/main.yml
+++ b/roles/proxysql/handlers/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: proxysql | handler | manage admin config
   proxysql_global_variables:
+    login_host: "{{ proxysql_admin_bind_address }}"
+    login_port: "{{ proxysql_admin_port }}"
     config_file: "~/.my.cnf"
     variable: "admin-{{ item.value.variable }}"
     value: "{{ item.value.variable_value }}"
@@ -9,6 +11,8 @@
 
 - name: proxysql | handler | manage mysql config
   proxysql_global_variables:
+    login_host: "{{ proxysql_admin_bind_address }}"
+    login_port: "{{ proxysql_admin_port }}"
     config_file: "~/.my.cnf"
     variable: "mysql-{{ item.value.variable }}"
     value: "{{ item.value.variable_value }}"
@@ -17,6 +21,8 @@
 
 - name: proxysql | handler | manage mysql options
   proxysql_global_variables:
+    login_host: "{{ proxysql_admin_bind_address }}"
+    login_port: "{{ proxysql_admin_port }}"
     config_file: "~/.my.cnf"
     variable: "mysql-{{ item.value.variable }}"
     value: "{{ item.value.variable_value }}"


### PR DESCRIPTION
##### SUMMARY
For when `proxysql_admin_bind_address` and `proxysql_admin_port` are overridden.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
roles/proxysql
