### PR TITLE
fix ci: too many blank lines

### DIFF
--- a/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/107-update_destination_hostgroup.yml
+++ b/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/107-update_destination_hostgroup.yml
@@ -59,4 +59,3 @@
   assert:
     that:
       - out is not changed
-


### PR DESCRIPTION
> ERROR: Found 1 yamllint issue(s) which need to be resolved:
ERROR: tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/107-update_destination_hostgroup.yml:62:1: empty-lines: too many blank lines (1 > 0)