### PR TITLE
Skip checking flagIN value before inserting rules (#108)

### DIFF
--- a/changelogs/fragments/107-update_destination_hostgroup.yml
+++ b/changelogs/fragments/107-update_destination_hostgroup.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - proxysql_query_rules_fast_routing - remove unnecessary ``flagIN`` check, that makes it impossible to update the ``destination_hostgroup`` parameter (https://github.com/ansible-collections/community.proxysql/pull/108).
+  - proxysql_query_rules_fast_routing - fix query parameter order, that prevents updating ``destination_hostgroup`` parameter (https://github.com/ansible-collections/community.proxysql/pull/108).

--- a/plugins/modules/proxysql_query_rules_fast_routing.py
+++ b/plugins/modules/proxysql_query_rules_fast_routing.py
@@ -240,8 +240,8 @@ class ProxyQueryRuleFastRouting(object):
 
         for col, val in iteritems(self.config_data):
             if val is not None and col not in ("username", "schemaname", "flagIN"):
+                query_data.insert(cols, val)
                 cols += 1
-                query_data.append(val)
                 if cols == 1:
                     query_string += " SET " + col + "= %s,"
                 else:
@@ -379,7 +379,7 @@ def main():
         try:
             if not query_rule.check_rule_cfg_exists(cursor):
                 if query_rule.config_data["username"] and query_rule.config_data["schemaname"] and \
-                   query_rule.config_data["flagIN"] and query_rule.check_rule_pk_exists(cursor):
+                   query_rule.check_rule_pk_exists(cursor):
                     query_rule.update_rule(module.check_mode, result, cursor)
                 else:
                     query_rule.create_rule(module.check_mode, result, cursor)

--- a/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/107-update_destination_hostgroup.yml
+++ b/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/107-update_destination_hostgroup.yml
@@ -1,0 +1,62 @@
+- name: Create fast routing rules
+  community.proxysql.proxysql_query_rules_fast_routing:
+    # rule args
+    username: user
+    schemaname: test_database
+    destination_hostgroup: 1
+    # auth args
+    login_user: admin
+    login_password: admin
+    state: present
+  register: out
+
+- debug:
+    var: out
+
+- name: verify create
+  assert:
+    that:
+      - out is changed
+      - out.rules[0].destination_hostgroup == "1"
+
+- name: Update destination hostgroup of previous fast routing rule
+  community.proxysql.proxysql_query_rules_fast_routing:
+    # rule args
+    username: user
+    schemaname: test_database
+    destination_hostgroup: 2
+    # auth args
+    login_user: admin
+    login_password: admin
+    state: present
+  register: out
+
+- debug:
+    var: out
+
+- name: verify change
+  assert:
+    that:
+      - out is changed
+      - out.rules[0].destination_hostgroup == "2"
+
+- name: Update destination hostgroup of previous fast routing rule (idempotent)
+  community.proxysql.proxysql_query_rules_fast_routing:
+    # rule args
+    username: user
+    schemaname: test_database
+    destination_hostgroup: 2
+    # auth args
+    login_user: admin
+    login_password: admin
+    state: present
+  register: out
+
+- debug:
+    var: out
+
+- name: verify no change
+  assert:
+    that:
+      - out is not changed
+

--- a/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/main.yml
+++ b/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/main.yml
@@ -82,6 +82,11 @@
     test_proxysql_query_rules_fast_routing_with_delayed_persist: true
     test_proxysql_query_rules_fast_routing_check_idempotence: true
 
+
+### other checks
+- name: test change destination hostgroup
+  include_tasks: 107-update_destination_hostgroup.yml
+
 ### teardown
 
 - name: "{{ role_name }} | teardown | perform teardown"


### PR DESCRIPTION
backport #108


* Skip checking flagIN value before inserting rules

* Add changelogs fragments

* Update changelogs/fragments/107-update_destination_hostgroup.yml

* include integration test

* fix typo

* more debug outputs

* more checks

* fix query_data order

* append changelog

Co-authored-by: Markus Bergholz <git@osuv.de>
