### PR TITLE
fix sanity, remove unused import

### DIFF
--- a/changelogs/fragments/2134ewfr.yml
+++ b/changelogs/fragments/2134ewfr.yml
@@ -1,0 +1,2 @@
+trivial:
+  - plugins/module_utils/mysql.py - remove unused import.

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -25,7 +25,6 @@ try:
 except ImportError:
     try:
         import MySQLdb as mysql_driver
-        import MySQLdb.cursors
         _mysql_cursor_param = 'cursorclass'
         HAS_MYSQL_PACKAGE = True
     except ImportError:


### PR DESCRIPTION
##### SUMMARY

```
 ERROR: Found 1 pylint issue(s) which need to be resolved:
ERROR: plugins/module_utils/mysql.py:28:8: unused-import: Unused import MySQLdb.cursors
```

https://github.com/ansible-collections/community.proxysql/actions/runs/4181129550/jobs/7242770370

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/mysql.py
