### PR TITLE
add pidfile location management

### DIFF
--- a/roles/proxysql/defaults/main.yml
+++ b/roles/proxysql/defaults/main.yml
@@ -9,6 +9,7 @@ proxysql_force_restart: false
 proxysql_user: proxysql
 proxysql_group: proxysql
 proxysql_datadir: /var/lib/proxysql
+proxysql_pidfile: "{{ proxysql_datadir }}/proxysql.pid"
 
 proxysql_restart_missing_heartbeats: 10
 

--- a/roles/proxysql/templates/proxysql.cnf.j2
+++ b/roles/proxysql/templates/proxysql.cnf.j2
@@ -1,6 +1,7 @@
 #jinja2: lstrip_blocks: "true"
 datadir="{{ proxysql_datadir }}"
 restart_on_missing_heartbeats={{ proxysql_restart_missing_heartbeats }}
+pidfile="{{ proxysql_pidfile }}"
 
 admin_variables=
 {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Possibility to store the proxysql pidfile in a non-persistent directory : https://github.com/sysown/proxysql/pull/3707
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pidfile location

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
https://github.com/sysown/proxysql/issues/3728
https://github.com/sysown/proxysql/pull/3707
This change must also be override in the service definition
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
