### PR TITLE
Add new module proxysql_galera_hostgroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ For more information about communication, refer to the [Ansible Communication gu
   - `proxysql_query_rules_fast_routing.py`: Modifies query rules for fast routing policies using the proxysql admin interface.
   - `proxysql_query_rules`: Modifies query rules using the proxysql admin interface.
   - `proxysql_replication_hostgroups`: Manages replication hostgroups using the proxysql admin.
+  - `proxysql_galera_hostgroups`: Manages galera hostgroups using the proxysql admin.
   - `proxysql_scheduler`: Adds or removes schedules from proxysql admin interface.
 - **Roles**:
   - proxysql

--- a/plugins/modules/proxysql_galera_hostgroups.py
+++ b/plugins/modules/proxysql_galera_hostgroups.py
@@ -17,7 +17,7 @@ description:
    - Unlike regular async replication, Galera hostgroup are NOT defined in mysql_replication_hostgroups table.
      Instead there is a separate table that is specifically designed for Galera hostgroups.
      The reason for this is that more advanced topology support is needed in order to accommodate
-     the deployment options available for Galera (e.g. controlled number of writers, cluster 
+     the deployment options available for Galera (e.g. controlled number of writers, cluster
      level replication thresholds etc.)
 options:
   writer_hostgroup:
@@ -57,8 +57,8 @@ options:
         and in the backup_writer_hostgroup after a topology change, these will be excluded from the reader_hostgroup
       - writer_is_also_reader - 1 nodes with `read_only=0` will be placed in the writer_hostgroup or
         backup_writer_hostgroup and are all also placed in reader_hostgroup after a topology change
-      - writer_is_also_reader - 2 Only the nodes with `read_only=0` which are placed in the in the 
-        backup_writer_hostgroup are also placed in the reader_hostgroup after a topology change i.e. 
+      - writer_is_also_reader - 2 Only the nodes with `read_only=0` which are placed in the in the
+        backup_writer_hostgroup are also placed in the reader_hostgroup after a topology change i.e.
         the nodes with `read_only=0` exceeding the defined `max_writers`.
     type: int
     choices: [ 0, 1, 2 ]
@@ -92,7 +92,7 @@ EXAMPLES = '''
 ---
 # This example adds a new galera hostgroup, it saves the mysql server config
 # to disk and loads it to a runtime and also enables the config which has
-# maximum of 2 writers from the writers_hostgroup. 
+# maximum of 2 writers from the writers_hostgroup.
 
 - name: Add a galera hostgroup
   community.proxysql_galera_hostgroups:
@@ -119,7 +119,7 @@ EXAMPLES = '''
     active: 0
 
 # This example removes a galera hostgroup from configuration,
-# saves the mysql server config to disk, and loads the mysql 
+# saves the mysql server config to disk, and loads the mysql
 # server config to runtime. It uses credentials in a supplied
 # config file to connect to the proxysql admin interface.
 
@@ -379,7 +379,7 @@ class ProxySQLGaleraHostgroup():
 
     def update_attr(self, cursor, attr):
         query_string = """UPDATE mysql_galera_hostgroups
-               SET %s = %s 
+               SET %s = %s
                WHERE writer_hostgroup = %s"""
 
         query_data = [attr, self.config_data[attr],
@@ -439,7 +439,7 @@ def main():
     if not proxysql_galera_group.galera_hostgroups_support:
         result["msg"] = "mysql_galera_hostgroups is only supported with proxysql 2.0.0 and above"
         module.exit_json(**result)
-        
+
     if proxysql_galera_group.state == "present":
         try:
             if not proxysql_galera_group.check_galera_group_config(cursor):

--- a/plugins/modules/proxysql_galera_hostgroups.py
+++ b/plugins/modules/proxysql_galera_hostgroups.py
@@ -4,16 +4,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.proxysql.plugins.module_utils.mysql import (
-    mysql_connect,
-    mysql_driver,
-    proxysql_common_argument_spec,
-    save_config_to_disk,
-    load_config_to_runtime,
-)
-
 
 __metaclass__ = type
 
@@ -54,7 +44,7 @@ options:
     description:
       - Enabled (1) or disabled (0) defined hostgroup configuration.
     type: int
-    choices: [ 0, 1 ]
+    choices: [0 , 1]
     default: 1
   max_writers:
     description:
@@ -63,11 +53,11 @@ options:
     default: 1
   writer_is_also_reader:
     description:
-      - writer_is_also_reader: 0 nodes with `read_only=0` will be placed either in the writer_hostgroup
+      - writer_is_also_reader - 0 nodes with `read_only=0` will be placed either in the writer_hostgroup
         and in the backup_writer_hostgroup after a topology change, these will be excluded from the reader_hostgroup
-      - writer_is_also_reader: 1 nodes with `read_only=0` will be placed in the writer_hostgroup or
+      - writer_is_also_reader - 1 nodes with `read_only=0` will be placed in the writer_hostgroup or
         backup_writer_hostgroup and are all also placed in reader_hostgroup after a topology change
-      - writer_is_also_reader: 2 Only the nodes with `read_only=0` which are placed in the in the 
+      - writer_is_also_reader - 2 Only the nodes with `read_only=0` which are placed in the in the 
         backup_writer_hostgroup are also placed in the reader_hostgroup after a topology change i.e. 
         the nodes with `read_only=0` exceeding the defined `max_writers`.
     type: int
@@ -141,7 +131,7 @@ EXAMPLES = '''
       reader_hostgroup: 2
       offline_hostgroup: 3
       active: 0
-    state: absent
+      state: absent
 '''
 
 RETURN = '''
@@ -167,6 +157,16 @@ stdout:
         "state": "present"
     }
 '''
+
+from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.proxysql.plugins.module_utils.mysql import (
+    mysql_connect,
+    mysql_driver,
+    proxysql_common_argument_spec,
+    save_config_to_disk,
+    load_config_to_runtime,
+)
 
 
 def perform_checks(module):

--- a/plugins/modules/proxysql_galera_hostgroups.py
+++ b/plugins/modules/proxysql_galera_hostgroups.py
@@ -1,0 +1,479 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.proxysql.plugins.module_utils.mysql import (
+    mysql_connect,
+    mysql_driver,
+    proxysql_common_argument_spec,
+    save_config_to_disk,
+    load_config_to_runtime,
+)
+
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: proxysql_galera_hostgroups
+author: "Tomas Palevičius (@tompal3)"
+short_description: Manages galera hostgroups using the proxysql admin
+                   interface
+description:
+   - Unlike regular async replication, Galera hostgroup are NOT defined in mysql_replication_hostgroups table.
+     Instead there is a separate table that is specifically designed for Galera hostgroups.
+     The reason for this is that more advanced topology support is needed in order to accommodate
+     the deployment options available for Galera (e.g. controlled number of writers, cluster 
+     level replication thresholds etc.)
+options:
+  writer_hostgroup:
+    description:
+      - Id of the hostgroup that will contain all the Galera nodes that are active writers.
+    type: int
+    required: true
+  backup_writer_hostgroup:
+    description:
+      - Id of the hostgroup that will contain all the Galera nodes that are standby writers.
+    type: int
+    required: true
+  reader_hostgroup:
+    description:
+      - Id of the hostgroup that will contain all the Galera nodes that are readers.
+    type: int
+    required: true
+  offline_hostgroup:
+    description:
+      - Id of the hostgroup all failed nodes will be moved to.
+    type: int
+    required: true
+  active:
+    description:
+      - Enabled (1) or disabled (0) defined hostgroup configuration.
+    type: int
+    choices: [ 0, 1 ]
+    default: 1
+  max_writers:
+    description:
+      - number of Read-Write instances populated in the writer hostgroup
+    type: int
+    default: 1
+  writer_is_also_reader:
+    description:
+      - writer_is_also_reader: 0 nodes with `read_only=0` will be placed either in the writer_hostgroup
+        and in the backup_writer_hostgroup after a topology change, these will be excluded from the reader_hostgroup
+      - writer_is_also_reader: 1 nodes with `read_only=0` will be placed in the writer_hostgroup or
+        backup_writer_hostgroup and are all also placed in reader_hostgroup after a topology change
+      - writer_is_also_reader: 2 Only the nodes with `read_only=0` which are placed in the in the 
+        backup_writer_hostgroup are also placed in the reader_hostgroup after a topology change i.e. 
+        the nodes with `read_only=0` exceeding the defined `max_writers`.
+    type: int
+    choices: [ 0, 1, 2 ]
+    default: 0
+  max_transactions_behind :
+    description:
+      - maximum number of writesets behind the cluster that ProxySQL should allow before shunning
+        the node to prevent stale reads
+    type: int
+    default: 0
+  comment:
+    description:
+      - Text field that can be used for any purposes defined by the user.
+    type: str
+    default: ""
+  state:
+    description:
+      - When C(present) - adds the galera hostgroup, when C(absent) -
+        removes the galera hostgroup.
+    type: str
+    choices: [ "present", "absent" ]
+    default: present
+extends_documentation_fragment:
+- community.proxysql.proxysql.managing_config
+- community.proxysql.proxysql.connectivity
+notes:
+- Supports C(check_mode).
+'''
+
+EXAMPLES = '''
+---
+# This example adds a new galera hostgroup, it saves the mysql server config
+# to disk and loads it to a runtime and also enables the config which has
+# maximum of 2 writers from the writers_hostgroup. 
+
+- name: Add a galera hostgroup
+  community.proxysql_galera_hostgroups:
+    login_user: "admin"
+    login_password: "admin"
+    writer_hostgroup: 1
+    backup_writer_hostgroup: 2
+    reader_hostgroup: 3
+    offline_hostgroup: 4
+    active: 1
+    max_writers: 2
+    writer_is_also_reader: 0
+
+# This example disables galera hostgroup by setting active to 0
+
+- name: Disable a galera hostgroup
+  community.proxysql_galera_hostgroups:
+    login_user: "admin"
+    login_password: "admin"
+    writer_hostgroup: 1
+    backup_writer_hostgroup: 2
+    reader_hostgroup: 3
+    offline_hostgroup: 4
+    active: 0
+
+# This example removes a galera hostgroup from configuration,
+# saves the mysql server config to disk, and loads the mysql 
+# server config to runtime. It uses credentials in a supplied
+# config file to connect to the proxysql admin interface.
+
+- name: Remove a galera hostgroup
+  community.proxysql_galera_hostgroups:
+      config_file: '/tmp/proxysql.cnf'
+      writer_hostgroup: 0
+      backup_writer_hostgroup: 1
+      reader_hostgroup: 2
+      offline_hostgroup: 3
+      active: 0
+    state: absent
+'''
+
+RETURN = '''
+stdout:
+    description: The galera hostgroup modified or removed from proxysql.
+    returned: On create/update will return the newly modified group, on delete
+              it will return the deleted record.
+    type: dict
+    "sample": {
+        "changed": true,
+        "galera_group": {
+            "active": "1",
+            "backup_writer_hostgroup": "1",
+            "comment": "test",
+            "max_transactions_behind": "0",
+            "max_writers": "3",
+            "offline_hostgroup": "3",
+            "reader_hostgroup": "2",
+            "writer_hostgroup": "0",
+            "writer_is_also_reader": "1"
+        },
+        "msg": "Updated galera hostgroups in check_mode",
+        "state": "present"
+    }
+'''
+
+
+def perform_checks(module):
+    """ Perform validation of
+        module.params variables
+
+    Args:
+        module (dict):
+    """
+    unique_hostgroups = {
+        "writer_hostgroup": module.params["writer_hostgroup"],
+        "backup_writer_hostgroup": module.params["backup_writer_hostgroup"],
+        "reader_hostgroup": module.params["reader_hostgroup"],
+        "offline_hostgroup": module.params["offline_hostgroup"]
+    }
+    positive_or_zero = {
+        "max_writers": module.params["max_writers"],
+        "max_transactions_behind": module.params["max_transactions_behind"]
+    }
+    positive_or_zero.update(unique_hostgroups)
+    status, hostgroup = check_if_unique(unique_hostgroups)
+    if not status:
+        module.fail_json(
+            msg="%s value is not unique. %s must have unique value" %
+            (hostgroup, list(unique_hostgroups.keys()))
+        )
+    status, hostgroup = check_positive_int(positive_or_zero)
+    if not status:
+        module.fail_json(
+            msg="%s must be an integer greater than or equal to 0" %
+            (hostgroup)
+        )
+
+
+def check_if_unique(param_dict):
+    """check if dict have unique values
+
+    Args:
+        param_dict (dict): dict of unique values to check
+
+    Returns:
+        Boolean: True if unique
+        hostgroup (string): incorect hostgroup
+    """
+    unique_values = {}
+    for hostgroup, value in param_dict.items():
+        if value not in unique_values.values():
+            unique_values[hostgroup] = value
+        else:
+            return False, hostgroup
+    return True, None
+
+
+def check_positive_int(param_dict):
+    """check if dict values are positive int or zero
+
+    Args:
+        param_dict (dict): dict of unique values to check
+
+    Returns:
+        Boolean: True if unique
+        hostgroup (string): incorect hostgroup
+    """
+    for hostgroup, value in param_dict.items():
+        if isinstance(value, int):
+            if not value < 0:
+                return True, None
+        return False, hostgroup
+
+
+class ProxySQLGaleraHostgroup():
+    """proxysql galera hostgroup class"""
+
+    def __init__(self, module, version):
+        self.state = module.params["state"]
+        self.save_to_disk = module.params["save_to_disk"]
+        self.load_to_runtime = module.params["load_to_runtime"]
+
+        config_data_keys = [
+            "writer_hostgroup",
+            "backup_writer_hostgroup",
+            "reader_hostgroup",
+            "offline_hostgroup",
+            "active",
+            "max_writers",
+            "writer_is_also_reader",
+            "max_transactions_behind",
+            "comment"
+        ]
+
+        self.config_data = dict((k, module.params[k])
+                                for k in config_data_keys)
+
+        self.galera_hostgroups_support = version.get("major") >= 2
+        self.check_mode = module.check_mode
+
+    def check_galera_group_config(self, cursor):
+        query_string = """SELECT count(*) AS `galera_groups`
+               FROM mysql_galera_hostgroups
+               WHERE writer_hostgroup = %s"""
+
+        query_data = [self.config_data['writer_hostgroup']]
+
+        cursor.execute(query_string, query_data)
+        check_count = cursor.fetchone()
+        return int(check_count["galera_groups"]) > 0
+
+    def get_galera_group_config(self, cursor):
+        query_string = """SELECT *
+               FROM mysql_galera_hostgroups
+               WHERE writer_hostgroup = %s"""
+
+        query_data = [self.config_data['writer_hostgroup']]
+
+        cursor.execute(query_string, query_data)
+        galera_group = cursor.fetchone()
+        return galera_group
+
+    def create_galera_group_config(self, cursor):
+        query_string = """INSERT INTO mysql_galera_hostgroups (
+               writer_hostgroup,
+               backup_writer_hostgroup,
+               reader_hostgroup,
+               offline_hostgroup,
+               active,
+               max_writers,
+               writer_is_also_reader,
+               max_transactions_behind,
+               comment)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)"""
+
+        query_data = [
+            self.config_data['writer_hostgroup'],
+            self.config_data['backup_writer_hostgroup'],
+            self.config_data['reader_hostgroup'],
+            self.config_data['offline_hostgroup'],
+            self.config_data['active'],
+            self.config_data['max_writers'],
+            self.config_data['writer_is_also_reader'],
+            self.config_data['max_transactions_behind'],
+            self.config_data['comment']
+        ]
+
+        cursor.execute(query_string, query_data)
+
+        return True
+
+    def delete_galera_group_config(self, cursor):
+        query_string = """DELETE FROM mysql_galera_hostgroups
+               WHERE writer_hostgroup = %s"""
+
+        query_data = [self.config_data['writer_hostgroup']]
+
+        cursor.execute(query_string, query_data)
+        return True
+
+    def manage_config(self, cursor, state):
+        if state and not self.check_mode:
+            if self.save_to_disk:
+                save_config_to_disk(cursor, "SERVERS")
+            if self.load_to_runtime:
+                load_config_to_runtime(cursor, "SERVERS")
+
+    def create_galera_group(self, result, cursor):
+        if not self.check_mode:
+            result["changed"] = self.create_galera_group_config(cursor)
+            result["msg"] = "Galera group have been added to mysql_galera_hostgroups"
+            result["galera_group"] = self.get_galera_group_config(cursor)
+            self.manage_config(cursor, result["changed"])
+        else:
+            result["changed"] = True
+            result["msg"] = (
+                "Galera group would have been added to"
+                + " mysql_galera_hostgroups, however"
+                + " check_mode is enabled."
+            )
+
+    def update_galera_group(self, result, cursor):
+        current = self.get_galera_group_config(cursor)
+
+        for key, value in current.items():
+            if key != "comment":
+                value = int(value)
+            if self.config_data.get(key):
+                if value != self.config_data[key]:
+                    result["changed"] = True
+                    result["msg"] = "Updated galera hostgroups in check_mode"
+                    if not self.check_mode:
+                        result["changed"] = True
+                        result["msg"] = "Updated galera hostgroups"
+                        self.update_attr(cursor, key)
+
+        result["galera_group"] = self.get_galera_group_config(cursor)
+
+        self.manage_config(cursor, result["changed"])
+
+    def delete_galera_group(self, result, cursor):
+        if not self.check_mode:
+            result["galera_group"] = self.get_galera_group_config(cursor)
+            result["changed"] = self.delete_galera_group_config(cursor)
+            result["msg"] = "Deleted galera group from mysql_galera_hostgroup"
+            self.manage_config(cursor, result["changed"])
+        else:
+            result["changed"] = True
+            result["msg"] = (
+                "galera group would have been deleted from"
+                + " mysql_replication_hostgroups, however"
+                + " check_mode is enabled."
+            )
+
+    def update_attr(self, cursor, attr):
+        query_string = """UPDATE mysql_galera_hostgroups
+               SET %s = %s 
+               WHERE writer_hostgroup = %s"""
+
+        query_data = [attr, self.config_data[attr],
+                      self.config_data['writer_hostgroup']]
+
+        cursor.execute(query_string, query_data)
+
+
+# ===========================================
+# Module execution.
+#
+
+
+def main():
+    argument_spec = proxysql_common_argument_spec()
+    argument_spec.update(
+        writer_hostgroup=dict(required=True, type="int"),
+        backup_writer_hostgroup=dict(required=True, type='int'),
+        reader_hostgroup=dict(required=True, type="int"),
+        offline_hostgroup=dict(required=True, type="int"),
+        active=dict(type="int", default=1, choices=[0, 1]),
+        max_writers=dict(type="int", default=1),
+        writer_is_also_reader=dict(type="int", default=0, choices=[0, 1, 2]),
+        max_transactions_behind=dict(type="int", default=0),
+        comment=dict(type="str", default=""),
+        state=dict(default="present", choices=["present", "absent"]),
+        save_to_disk=dict(default=True, type="bool"),
+        load_to_runtime=dict(default=True, type="bool"),
+    )
+
+    module = AnsibleModule(supports_check_mode=True,
+                           argument_spec=argument_spec)
+
+    perform_checks(module)
+
+    login_user = module.params["login_user"]
+    login_password = module.params["login_password"]
+    config_file = module.params["config_file"]
+
+    cursor = None
+    try:
+        cursor, db_conn, version = mysql_connect(
+            module, login_user, login_password, config_file, cursor_class="DictCursor"
+        )
+    except mysql_driver.Error as e:
+        module.fail_json(
+            msg="unable to connect to ProxySQL Admin Module.. %s" % (
+                to_native(e))
+        )
+
+    proxysql_galera_group = ProxySQLGaleraHostgroup(module, version)
+    result = {}
+
+    result["state"] = proxysql_galera_group.state
+    result["changed"] = False
+
+    if not proxysql_galera_group.galera_hostgroups_support:
+        result["msg"] = "mysql_galera_hostgroups is only supported with proxysql 2.0.0 and above"
+        module.exit_json(**result)
+        
+    if proxysql_galera_group.state == "present":
+        try:
+            if not proxysql_galera_group.check_galera_group_config(cursor):
+                proxysql_galera_group.create_galera_group(result, cursor)
+            else:
+                proxysql_galera_group.update_galera_group(result, cursor)
+
+                result["galera_group"] = proxysql_galera_group.get_galera_group_config(
+                    cursor)
+
+        except mysql_driver.Error as e:
+            module.fail_json(
+                msg="unable to modify galera hostgroup.. %s" % (to_native(e))
+            )
+
+    elif proxysql_galera_group.state == "absent":
+        try:
+            if proxysql_galera_group.check_galera_group_config(cursor):
+                proxysql_galera_group.delete_galera_group(result, cursor)
+            else:
+                result["changed"] = False
+                result["msg"] = (
+                    "The galera group is already absent from the"
+                    + " mysql_galera_hostgroups memory"
+                    + " configuration"
+                )
+
+        except mysql_driver.Error as e:
+            module.fail_json(
+                msg="unable to delete galera hostgroup.. %s" % (to_native(e))
+            )
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/defaults/main.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+test_writer_hostgroup: 1
+test_backup_writer_hostgroup: 2
+test_reader_hostgroup: 3
+test_offline_hostgroup: 4
+
+test_proxysql_galera_hostgroups_check_mode: false
+test_proxysql_galera_hostgroups_in_memory_only: false
+test_proxysql_galera_hostgroups_with_delayed_persist: false
+test_proxysql_galera_hostgroups_check_idempotence: false
+test_proxysql_galera_hostgroups_cleanup_after_test: true

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/meta/main.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_proxysql

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/base_test.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/base_test.yml
@@ -1,0 +1,71 @@
+---
+### prepare
+- name: "{{ role_name }} | {{ current_test }} | are we performing a delete"
+  set_fact:
+    test_delete: "{{ current_test | regex_search('^test_delete') | ternary(true, false) }}"
+
+- name: "{{ role_name }} | {{ current_test }} | ensure we're in a clean state when we start"
+  include_tasks: "{{ test_delete|ternary('setup_test_galera_hostgroups', 'cleanup_test_galera_hostgroups') }}.yml"
+  when: not test_proxysql_galera_hostgroups_check_idempotence
+
+### when
+
+- name: "{{ role_name }} | {{ current_test }} | {{ test_delete|ternary('delete','create') }} test mysql galera hostgroup"
+  proxysql_galera_hostgroups:
+    login_user: admin
+    login_password: admin
+    writer_hostgroup: "{{ test_writer_hostgroup }}"
+    backup_writer_hostgroup: "{{ test_backup_writer_hostgroup }}"
+    reader_hostgroup: "{{ test_reader_hostgroup }}"
+    offline_hostgroup: "{{ test_offline_hostgroup }}"
+    state: "{{ test_delete|ternary('absent', 'present') }}"
+    save_to_disk: "{{ not test_proxysql_galera_hostgroups_in_memory_only }}"
+    load_to_runtime: "{{ not test_proxysql_galera_hostgroups_in_memory_only }}"
+  check_mode: "{{ test_proxysql_galera_hostgroups_check_mode }}"
+  register: status
+
+- name: "{{ role_name }} | {{ current_test }} | persist the changes to disk, and load to runtime"
+  block:
+    - name: "{{ role_name }} | {{ current_test }} | save the galera hostgroups config from memory to disk"
+      proxysql_manage_config:
+        login_user: admin
+        login_password: admin
+        action: SAVE
+        config_settings: MYSQL SERVERS
+        direction: TO
+        config_layer: DISK
+
+    - name: "{{ role_name }} | {{ current_test }} | load the galera hostgroups config from memory to runtime"
+      proxysql_manage_config:
+        login_user: admin
+        login_password: admin
+        action: LOAD
+        config_settings: MYSQL SERVERS
+        direction: TO
+        config_layer: RUNTIME
+
+  when: test_proxysql_galera_hostgroups_with_delayed_persist
+
+- name: "{{ role_name }} | {{ current_test }} | check if test galera hostgroups exists in memory"
+  shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"
+    SELECT writer_hostgroup || ',' || backup_writer_hostgroup || ',' || reader_hostgroup || ',' || offline_hostgroup 
+    FROM mysql_galera_hostgroups 
+    WHERE writer_hostgroup = '{{ test_writer_hostgroup }}' AND backup_writer_hostgroup = '{{ test_backup_writer_hostgroup }}' 
+    AND reader_hostgroup = '{{ test_reader_hostgroup }}' AND offline_hostgroup = '{{ test_offline_hostgroup }}'"
+  register: memory_result
+
+- name: "{{ role_name }} | {{ current_test }} | check if test galera hostgroups exists on disk"
+  shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"
+    SELECT writer_hostgroup || ',' || backup_writer_hostgroup || ',' || reader_hostgroup || ',' || offline_hostgroup 
+    FROM disk.mysql_galera_hostgroups 
+    WHERE writer_hostgroup = '{{ test_writer_hostgroup }}' AND backup_writer_hostgroup = '{{ test_backup_writer_hostgroup }}' 
+    AND reader_hostgroup = '{{ test_reader_hostgroup }}' AND offline_hostgroup = '{{ test_offline_hostgroup }}'"
+  register: disk_result
+
+- name: "{{ role_name }} | {{ current_test }} | check if test galera hostgroups exists in runtime"
+  shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"
+    SELECT writer_hostgroup || ',' || backup_writer_hostgroup || ',' || reader_hostgroup || ',' || offline_hostgroup 
+    FROM runtime_mysql_galera_hostgroups 
+    WHERE writer_hostgroup = '{{ test_writer_hostgroup }}' AND backup_writer_hostgroup = '{{ test_backup_writer_hostgroup }}' 
+    AND reader_hostgroup = '{{ test_reader_hostgroup }}' AND offline_hostgroup = '{{ test_offline_hostgroup }}'"
+  register: runtime_result

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/base_test.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/base_test.yml
@@ -48,24 +48,24 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if test galera hostgroups exists in memory"
   shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"
-    SELECT writer_hostgroup || ',' || backup_writer_hostgroup || ',' || reader_hostgroup || ',' || offline_hostgroup 
-    FROM mysql_galera_hostgroups 
-    WHERE writer_hostgroup = '{{ test_writer_hostgroup }}' AND backup_writer_hostgroup = '{{ test_backup_writer_hostgroup }}' 
+    SELECT writer_hostgroup || ',' || backup_writer_hostgroup || ',' || reader_hostgroup || ',' || offline_hostgroup
+    FROM mysql_galera_hostgroups
+    WHERE writer_hostgroup = '{{ test_writer_hostgroup }}' AND backup_writer_hostgroup = '{{ test_backup_writer_hostgroup }}'
     AND reader_hostgroup = '{{ test_reader_hostgroup }}' AND offline_hostgroup = '{{ test_offline_hostgroup }}'"
   register: memory_result
 
 - name: "{{ role_name }} | {{ current_test }} | check if test galera hostgroups exists on disk"
   shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"
-    SELECT writer_hostgroup || ',' || backup_writer_hostgroup || ',' || reader_hostgroup || ',' || offline_hostgroup 
-    FROM disk.mysql_galera_hostgroups 
-    WHERE writer_hostgroup = '{{ test_writer_hostgroup }}' AND backup_writer_hostgroup = '{{ test_backup_writer_hostgroup }}' 
+    SELECT writer_hostgroup || ',' || backup_writer_hostgroup || ',' || reader_hostgroup || ',' || offline_hostgroup
+    FROM disk.mysql_galera_hostgroups
+    WHERE writer_hostgroup = '{{ test_writer_hostgroup }}' AND backup_writer_hostgroup = '{{ test_backup_writer_hostgroup }}'
     AND reader_hostgroup = '{{ test_reader_hostgroup }}' AND offline_hostgroup = '{{ test_offline_hostgroup }}'"
   register: disk_result
 
 - name: "{{ role_name }} | {{ current_test }} | check if test galera hostgroups exists in runtime"
   shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"
-    SELECT writer_hostgroup || ',' || backup_writer_hostgroup || ',' || reader_hostgroup || ',' || offline_hostgroup 
-    FROM runtime_mysql_galera_hostgroups 
-    WHERE writer_hostgroup = '{{ test_writer_hostgroup }}' AND backup_writer_hostgroup = '{{ test_backup_writer_hostgroup }}' 
+    SELECT writer_hostgroup || ',' || backup_writer_hostgroup || ',' || reader_hostgroup || ',' || offline_hostgroup
+    FROM runtime_mysql_galera_hostgroups
+    WHERE writer_hostgroup = '{{ test_writer_hostgroup }}' AND backup_writer_hostgroup = '{{ test_backup_writer_hostgroup }}'
     AND reader_hostgroup = '{{ test_reader_hostgroup }}' AND offline_hostgroup = '{{ test_offline_hostgroup }}'"
   register: runtime_result

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/cleanup_test_galera_hostgroups.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/cleanup_test_galera_hostgroups.yml
@@ -1,0 +1,12 @@
+---
+- name: "{{ role_name }} | {{ current_test }} | ensure we're in a clean state when we start/finish"
+  block:
+
+    - name: "{{ role_name }} | {{ current_test }} | ensure no galera hostgroups are created"
+      shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"DELETE FROM mysql_galera_hostgroups"
+
+    - name: "{{ role_name }} | {{ current_test }} | ensure no galera hostgroups are saved on disk"
+      shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"SAVE MYSQL SERVERS TO DISK"
+
+    - name: "{{ role_name }} | {{ current_test }} | ensure no galera hostgroups are loaded to runtime"
+      shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"LOAD MYSQL SERVERS TO RUNTIME"

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/cleanup_test_galera_hostgroups.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/cleanup_test_galera_hostgroups.yml
@@ -1,7 +1,6 @@
 ---
 - name: "{{ role_name }} | {{ current_test }} | ensure we're in a clean state when we start/finish"
   block:
-
     - name: "{{ role_name }} | {{ current_test }} | ensure no galera hostgroups are created"
       shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"DELETE FROM mysql_galera_hostgroups"
 

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/main.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/main.yml
@@ -1,0 +1,182 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+### tests
+
+- name: "{{ role_name }} | test_create_using_check_mode | test create galera hostgroups using check mode"
+  import_tasks: test_create_using_check_mode.yml
+  vars:
+    test_proxysql_galera_hostgroups_check_mode: true
+
+- name: "{{ role_name }} | test_delete_using_check_mode | test delete galera hostgroups using check mode"
+  import_tasks: test_delete_using_check_mode.yml
+  vars:
+    test_proxysql_galera_hostgroups_check_mode: true
+
+- name: "{{ role_name }} | test_create_galera_hostgroups | test create galera hostgroups"
+  import_tasks: test_create_galera_hostgroups.yml
+  vars:
+    test_proxysql_galera_hostgroups_cleanup_after_test: false
+- name: "{{ role_name }} | test_create_galera_hostgroups | test idempotence of create galera hostgroups"
+  import_tasks: test_create_galera_hostgroups.yml
+  vars:
+    test_proxysql_galera_hostgroups_check_idempotence: true
+
+- name: "{{ role_name }} | test_delete_galera_hostgroups | test delete galera hostgroups"
+  import_tasks: test_delete_galera_hostgroups.yml
+  vars:
+    test_proxysql_galera_hostgroups_cleanup_after_test: false
+- name: "{{ role_name }} | test_delete_galera_hostgroups | test idempotence of delete galera hostgroups"
+  import_tasks: test_delete_galera_hostgroups.yml
+  vars:
+    test_proxysql_galera_hostgroups_check_idempotence: true
+
+- name: "{{ role_name }} | test_create_galera_hostgroups_in_memory_only | test create galera hostgroups in memory"
+  import_tasks: test_create_galera_hostgroups_in_memory_only.yml
+  vars:
+    test_proxysql_galera_hostgroups_in_memory_only: true
+    test_proxysql_galera_hostgroups_cleanup_after_test: false
+- name: "{{ role_name }} | test_create_galera_hostgroups_in_memory_only | test idempotence of create galera hostgroups in memory"
+  import_tasks: test_create_galera_hostgroups_in_memory_only.yml
+  vars:
+    test_proxysql_galera_hostgroups_in_memory_only: true
+    test_proxysql_galera_hostgroups_check_idempotence: true
+
+- name: "{{ role_name }} | test_delete_galera_hostgroups_in_memory_only | test delete galera hostgroups in memory"
+  import_tasks: test_delete_galera_hostgroups_in_memory_only.yml
+  vars:
+    test_proxysql_galera_hostgroups_in_memory_only: true
+    test_proxysql_galera_hostgroups_cleanup_after_test: false
+- name: "{{ role_name }} | test_delete_galera_hostgroups_in_memory_only | test idempotence of delete galera hostgroups in memory"
+  import_tasks: test_delete_galera_hostgroups_in_memory_only.yml
+  vars:
+    test_proxysql_galera_hostgroups_in_memory_only: true
+    test_proxysql_galera_hostgroups_check_idempotence: true
+
+- name: "{{ role_name }} | test_create_galera_hostgroups_with_delayed_persist | test create galera hostgroups with delayed save to disk/load to runtime"
+  import_tasks: test_create_galera_hostgroups_with_delayed_persist.yml
+  vars:
+    test_proxysql_galera_hostgroups_in_memory_only: true
+    test_proxysql_galera_hostgroups_with_delayed_persist: true
+    test_proxysql_galera_hostgroups_cleanup_after_test: false
+- name: "{{ role_name }} | test_create_galera_hostgroups_with_delayed_persist | test idempotence of create galera hostgroups with delayed save to disk/load to runtime"
+  import_tasks: test_create_galera_hostgroups_with_delayed_persist.yml
+  vars:
+    test_proxysql_galera_hostgroups_in_memory_only: true
+    test_proxysql_galera_hostgroups_with_delayed_persist: true
+    test_proxysql_galera_hostgroups_check_idempotence: true
+
+- name: "{{ role_name }} | test_delete_galera_hostgroups_with_delayed_persist | test delete galera hostgroups with delayed save to disk/load to runtime"
+  import_tasks: test_delete_galera_hostgroups_with_delayed_persist.yml
+  vars:
+    test_proxysql_galera_hostgroups_in_memory_only: true
+    test_proxysql_galera_hostgroups_with_delayed_persist: true
+    test_proxysql_galera_hostgroups_cleanup_after_test: false
+- name: "{{ role_name }} | test_delete_galera_hostgroups_with_delayed_persist | test idempotence of delete galera hostgroups with delayed save to disk/load to runtime"
+  import_tasks: test_delete_galera_hostgroups_with_delayed_persist.yml
+  vars:
+    test_proxysql_galera_hostgroups_in_memory_only: true
+    test_proxysql_galera_hostgroups_with_delayed_persist: true
+    test_proxysql_galera_hostgroups_check_idempotence: true
+
+- name: "gather proxysql informations"
+  community.proxysql.proxysql_info:
+    login_user: admin
+    login_password: admin
+  register: proxysql_information
+
+- name: create galera hostgroup
+  community.proxysql.proxysql_galera_hostgroups:
+    login_user: admin
+    login_password: admin
+    writer_hostgroup: 100
+    backup_writer_hostgroup: 200
+    reader_hostgroup: 300
+    offline_hostgroup: 400
+  register: special_condition
+
+- name: verify change
+  assert:
+    that:
+      - special_condition is changed
+
+- name: >
+    test conditions that are failing in the past
+  block:
+    - name: change backup_writer_hostgroup
+      community.proxysql.proxysql_galera_hostgroups:
+        login_user: admin
+        login_password: admin
+        writer_hostgroup: 100
+        backup_writer_hostgroup: 500
+        reader_hostgroup: 300
+        offline_hostgroup: 400
+      register: special_condition
+
+    - name: verify change
+      assert:
+        that:
+          - special_condition is changed
+
+    - name: change reader_hostgroup
+      community.proxysql.proxysql_galera_hostgroups:
+        login_user: admin
+        login_password: admin
+        writer_hostgroup: 100
+        backup_writer_hostgroup: 500
+        reader_hostgroup: 600
+        offline_hostgroup: 400
+      register: special_condition
+
+    - name: verify change
+      assert:
+        that:
+          - special_condition is changed
+
+    - name: change offline_hostgroup
+      community.proxysql.proxysql_galera_hostgroups:
+        login_user: admin
+        login_password: admin
+        writer_hostgroup: 100
+        backup_writer_hostgroup: 500
+        reader_hostgroup: 600
+        offline_hostgroup: 700
+      register: special_condition
+
+    - name: verify change
+      assert:
+        that:
+          - special_condition is changed
+    
+    - name: change reader_hostgroup | verify proxysql version
+      community.proxysql.proxysql_galera_hostgroups:
+        login_user: admin
+        login_password: admin
+        writer_hostgroup: 100
+        backup_writer_hostgroup: 200
+        reader_hostgroup: 300
+        offline_hostgroup: 400
+      register: special_condition
+
+    - name: verify check_mode - no change for proxysql < 2
+      when: proxysql_information.version.major < 2
+      assert:
+        that:
+          - special_condition is not changed
+
+    - name: verify check_mode - change for proxysql > 2
+      when: proxysql_information.version.major >= 2
+      assert:
+        that:
+          - special_condition is changed
+
+
+
+
+### teardown
+
+- name: "{{ role_name }} | teardown | perform teardown"
+  import_tasks: teardown.yml

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/main.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/main.yml
@@ -150,7 +150,7 @@
       assert:
         that:
           - special_condition is changed
-    
+
     - name: change reader_hostgroup | verify proxysql version
       community.proxysql.proxysql_galera_hostgroups:
         login_user: admin
@@ -172,9 +172,6 @@
       assert:
         that:
           - special_condition is changed
-
-
-
 
 ### teardown
 

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/setup_test_galera_hostgroups.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/setup_test_galera_hostgroups.yml
@@ -1,0 +1,11 @@
+---
+- name: "{{ role_name }} | {{ current_test }}  | ensure test galera hostgroups is created when we start"
+  block:
+    - name: "{{ role_name }} | {{ current_test }}  | ensure test galera hostgroups is created in memory"
+      shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"INSERT OR REPLACE INTO mysql_galera_hostgroups (writer_hostgroup, backup_writer_hostgroup, reader_hostgroup, offline_hostgroup) VALUES ('{{ test_writer_hostgroup }}', '{{ test_backup_writer_hostgroup }}', '{{ test_reader_hostgroup }}', '{{ test_offline_hostgroup }}')"
+
+    - name: "{{ role_name }} | {{ current_test }}  | ensure test galera hostgroups is created on disk"
+      shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"SAVE MYSQL SERVERS TO DISK"
+
+    - name: "{{ role_name }} | {{ current_test }}  | ensure test galera hostgroups is created in runtime"
+      shell: mysql -uadmin -padmin -h127.0.0.1 -P6032 -BNe"LOAD MYSQL SERVERS TO RUNTIME"

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/teardown.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/teardown.yml
@@ -1,0 +1,6 @@
+---
+- name: "{{ role_name }} | teardown | uninstall proxysql"
+  apt:
+    name: proxysql
+    purge: true
+    state: absent

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_create_galera_hostgroups.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_create_galera_hostgroups.yml
@@ -1,0 +1,31 @@
+---
+- name: "{{ role_name }} | test_create_galera_hostgroups | set current test"
+  set_fact:
+    current_test: test_create_galera_hostgroups
+
+- include_tasks: base_test.yml
+
+### then
+
+- name: "{{ role_name }} | {{ current_test }} | check if create galera hostgroups reported a change"
+  assert:
+    that:
+      - "status is {{ test_proxysql_galera_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+
+- name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups did make a change in memory"
+  assert:
+    that: memory_result.stdout == '{{ test_writer_hostgroup }},{{ test_backup_writer_hostgroup }},{{ test_reader_hostgroup }},{{ test_offline_hostgroup }}'
+
+- name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups did make a change on disk"
+  assert:
+    that: disk_result.stdout == '{{ test_writer_hostgroup }},{{ test_backup_writer_hostgroup }},{{ test_reader_hostgroup }},{{ test_offline_hostgroup }}'
+
+- name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups did make a change to runtime"
+  assert:
+    that: runtime_result.stdout == '{{ test_writer_hostgroup }},{{ test_backup_writer_hostgroup }},{{ test_reader_hostgroup }},{{ test_offline_hostgroup }}'
+
+### perform cleanup
+
+- name: "{{ role_name }} | {{ current_test }} | ensure we're in a clean state when we finish"
+  import_tasks: cleanup_test_galera_hostgroups.yml
+  when: test_proxysql_galera_hostgroups_cleanup_after_test

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_create_galera_hostgroups_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_create_galera_hostgroups_in_memory_only.yml
@@ -1,0 +1,31 @@
+---
+- name: "{{ role_name }} | test_create_galera_hostgroups_in_memory_only | set current test"
+  set_fact:
+    current_test: test_create_galera_hostgroups_in_memory_only
+
+- include_tasks: base_test.yml
+
+### then
+
+- name: "{{ role_name }} | {{ current_test }} | check if create galera hostgroups reported a change"
+  assert:
+    that:
+      - "status is {{ test_proxysql_galera_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+
+- name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups did make a change in memory"
+  assert:
+    that: memory_result.stdout == '{{ test_writer_hostgroup }},{{ test_backup_writer_hostgroup }},{{ test_reader_hostgroup }},{{ test_offline_hostgroup }}'
+
+- name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups didn't make a change on disk"
+  assert:
+    that: disk_result.stdout|length == 0
+
+- name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups didn't make a change to runtime"
+  assert:
+    that: runtime_result.stdout|length == 0
+
+### perform cleanup
+
+- name: "{{ role_name }} | {{ current_test }} | ensure we're in a clean state when we finish"
+  import_tasks: cleanup_test_galera_hostgroups.yml
+  when: test_proxysql_galera_hostgroups_cleanup_after_test

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_create_galera_hostgroups_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_create_galera_hostgroups_with_delayed_persist.yml
@@ -1,0 +1,31 @@
+---
+- name: "{{ role_name }} | test_create_galera_hostgroups_with_delayed_persist | set current test"
+  set_fact:
+    current_test: test_create_galera_hostgroups_with_delayed_persist
+
+- include_tasks: base_test.yml
+
+### then
+
+- name: "{{ role_name }} | {{ current_test }} | check if create galera hostgroups reported a change"
+  assert:
+    that:
+      - "status is {{ test_proxysql_galera_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+
+- name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups did make a change in memory"
+  assert:
+    that: memory_result.stdout == '{{ test_writer_hostgroup }},{{ test_backup_writer_hostgroup }},{{ test_reader_hostgroup }},{{ test_offline_hostgroup }}'
+
+- name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups did make a change on disk"
+  assert:
+    that: disk_result.stdout == '{{ test_writer_hostgroup }},{{ test_backup_writer_hostgroup }},{{ test_reader_hostgroup }},{{ test_offline_hostgroup }}'
+
+- name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups did make a change to runtime"
+  assert:
+    that: runtime_result.stdout == '{{ test_writer_hostgroup }},{{ test_backup_writer_hostgroup }},{{ test_reader_hostgroup }},{{ test_offline_hostgroup }}'
+
+### perform cleanup
+
+- name: "{{ role_name }} | {{ current_test }} | ensure we're in a clean state when we finish"
+  import_tasks: cleanup_test_galera_hostgroups.yml
+  when: test_proxysql_galera_hostgroups_cleanup_after_test

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_create_using_check_mode.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_create_using_check_mode.yml
@@ -1,0 +1,30 @@
+---
+- name: "{{ role_name }} | test_create_using_check_mode | set current test"
+  set_fact:
+    current_test: test_create_using_check_mode
+
+- include_tasks: base_test.yml
+
+### then
+
+- name: "{{ role_name }} | {{ current_test }} | check if create galera hostgroups in check mode reported a change"
+  assert:
+    that:
+      - status is changed
+
+- name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups in check mode didn't make a change in memory"
+  assert:
+    that: memory_result.stdout|length == 0
+
+- name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups in check mode didn't make a change on disk"
+  assert:
+    that: disk_result.stdout|length == 0
+
+- name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups in check mode didn't make a change to runtime"
+  assert:
+    that: runtime_result.stdout|length == 0
+
+### perform cleanup
+
+- name: "{{ role_name }} | {{ current_test }} | ensure we're in a clean state when we finish"
+  import_tasks: cleanup_test_galera_hostgroups.yml

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_delete_galera_hostgroups.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_delete_galera_hostgroups.yml
@@ -1,0 +1,31 @@
+---
+- name: "{{ role_name }} | test_delete_galera_hostgroups | set current test"
+  set_fact:
+    current_test: test_delete_galera_hostgroups
+
+- include_tasks: base_test.yml
+
+### then
+
+- name: "{{ role_name }} | {{ current_test }} | check if delete galera hostgroups reported a change"
+  assert:
+    that:
+      - "status is {{ test_proxysql_galera_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+
+- name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups did make a change in memory"
+  assert:
+    that: memory_result.stdout|length == 0
+
+- name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups did make a change on disk"
+  assert:
+    that: disk_result.stdout|length == 0
+
+- name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups did make a change to runtime"
+  assert:
+    that: runtime_result.stdout|length == 0
+
+### perform cleanup
+
+- name: "{{ role_name }} | {{ current_test }} | ensure we're in a clean state when we finish"
+  import_tasks: cleanup_test_galera_hostgroups.yml
+  when: test_proxysql_galera_hostgroups_cleanup_after_test

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_delete_galera_hostgroups_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_delete_galera_hostgroups_in_memory_only.yml
@@ -1,0 +1,30 @@
+---
+- name: "{{ role_name }} | test_delete_galera_hostgroups_in_memory_only | set current test"
+  set_fact:
+    current_test: test_delete_galera_hostgroups_in_memory_only
+
+- include_tasks: base_test.yml
+
+### then
+
+- name: "{{ role_name }} | {{ current_test }} | check if delete galera hostgroups reported a change"
+  assert:
+    that:
+      - "status is {{ test_proxysql_galera_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+
+- name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups didn't make a change in memory"
+  assert:
+    that: memory_result.stdout|length == 0
+
+- name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups did make a change on disk"
+  assert:
+    that: disk_result.stdout == '{{ test_writer_hostgroup }},{{ test_backup_writer_hostgroup }},{{ test_reader_hostgroup }},{{ test_offline_hostgroup }}'
+
+- name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups did make a change to runtime"
+  assert:
+    that: runtime_result.stdout == '{{ test_writer_hostgroup }},{{ test_backup_writer_hostgroup }},{{ test_reader_hostgroup }},{{ test_offline_hostgroup }}'
+### perform cleanup
+
+- name: "{{ role_name }} | {{ current_test }} | ensure we're in a clean state when we finish"
+  import_tasks: cleanup_test_galera_hostgroups.yml
+  when: test_proxysql_galera_hostgroups_cleanup_after_test

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_delete_galera_hostgroups_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_delete_galera_hostgroups_with_delayed_persist.yml
@@ -1,0 +1,31 @@
+---
+- name: "{{ role_name }} | test_delete_galera_hostgroups_with_delayed_persist | set current test"
+  set_fact:
+    current_test: test_delete_galera_hostgroups_with_delayed_persist
+
+- include_tasks: base_test.yml
+
+### then
+
+- name: "{{ role_name }} | {{ current_test }} | check if delete galera hostgroups reported a change"
+  assert:
+    that:
+      - "status is {{ test_proxysql_galera_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+
+- name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups did make a change in memory"
+  assert:
+    that: memory_result.stdout|length == 0
+
+- name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups did make a change on disk"
+  assert:
+    that: disk_result.stdout|length == 0
+
+- name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups did make a change to runtime"
+  assert:
+    that: runtime_result.stdout|length == 0
+
+### perform cleanup
+
+- name: "{{ role_name }} | {{ current_test }} | ensure we're in a clean state when we finish"
+  import_tasks: cleanup_test_galera_hostgroups.yml
+  when: test_proxysql_galera_hostgroups_cleanup_after_test

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_delete_using_check_mode.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_delete_using_check_mode.yml
@@ -1,0 +1,30 @@
+---
+- name: "{{ role_name }} | test_delete_using_check_mode | set current test"
+  set_fact:
+    current_test: test_delete_using_check_mode
+
+- include_tasks: base_test.yml
+
+### then
+
+- name: "{{ role_name }} | {{ current_test }} | check if delete galera hostgroups in check mode reported a change"
+  assert:
+    that:
+      - status is changed
+
+- name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups in check mode didn't make a change in memory"
+  assert:
+    that: memory_result.stdout == '{{ test_writer_hostgroup }},{{ test_backup_writer_hostgroup }},{{ test_reader_hostgroup }},{{ test_offline_hostgroup }}'
+
+- name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups in check mode didn't make a change on disk"
+  assert:
+    that: disk_result.stdout == '{{ test_writer_hostgroup }},{{ test_backup_writer_hostgroup }},{{ test_reader_hostgroup }},{{ test_offline_hostgroup }}'
+
+- name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups in check mode didn't make a change to runtime"
+  assert:
+    that: runtime_result.stdout == '{{ test_writer_hostgroup }},{{ test_backup_writer_hostgroup }},{{ test_reader_hostgroup }},{{ test_offline_hostgroup }}'
+
+### perform cleanup
+
+- name: "{{ role_name }} | {{ current_test }} | ensure we're in a clean state when we finish"
+  import_tasks: cleanup_test_galera_hostgroups.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add new role for managing `mysql_galera_hostgroups` table in proxysql

as discused in: https://github.com/ansible-collections/community.proxysql/issues/6
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxysql_galera_hostgroups
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
