### PR TITLE
module_utils: fix version parsing failures when there's no suffix part in version

### DIFF
--- a/changelogs/fragments/0-proxysql.yml
+++ b/changelogs/fragments/0-proxysql.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- module_utils - fix ProxySQL version parsing that fails when a suffix wasn't present in the version (https://github.com/ansible-collections/community.proxysql/issues/154).

--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -53,7 +53,7 @@ def _version(cursor):
     version['major'] = int(_version[0])
     version['minor'] = int(_version[1])
     version['release'] = int(_version[2])
-    version['suffix'] = raw_version[1]
+    version['suffix'] = raw_version[1] if len(raw_version) > 1 else None
 
     return version
 


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.proxysql/issues/154