### PR TITLE
Fix integration tests for Ansible 2.19.

### DIFF
--- a/tests/integration/targets/setup_proxysql/defaults/main.yml
+++ b/tests/integration/targets/setup_proxysql/defaults/main.yml
@@ -1,5 +1,3 @@
 ---
 proxysql_download_src: https://github.com/sysown/proxysql/releases/download
-proxysql_version: 2.3.2
-
-proxysql_mysql_client_version: 5.7
+proxysql_version: 2.7.2

--- a/tests/integration/targets/setup_proxysql/tasks/install.yml
+++ b/tests/integration/targets/setup_proxysql/tasks/install.yml
@@ -1,4 +1,36 @@
 ---
+- name: Override systemd unit for tests
+  vars:
+    proxysql_systemd_override_path: /etc/systemd/system/proxysql.service.d
+  block:
+    # In Ubuntu 24.04, the combination of `PrivateDevices` and
+    # `RestrictAddressFamilies` was leading to a need for the `CAP_SYS_ADMIN`
+    # capability within the `ansible-test` docker container. These stanzas
+    # within systemd are intended to sandbox processes, reducing the attack
+    # surface of units run within it.
+
+    # While I think both of these systemd stanzas may make sense for
+    # production deployments, I am not sure they make sense on ephemeral test
+    # containers --- especially if it requires additional system privileges by
+    # running the container in privileged mode.
+    - name: Create systemd override directory
+      ansible.builtin.file:
+        path: '{{ proxysql_systemd_override_path }}'
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+    - name: Create systemd override file
+      ansible.builtin.copy:
+        dest: '{{ proxysql_systemd_override_path }}/docker-friendly-tests.conf'
+        owner: root
+        group: root
+        mode: '0644'
+        content: |
+          [Service]
+          PrivateDevices=no
+          RestrictAddressFamilies=
+
 - name: proxysql | install | add apt signing key for percona
   apt_key:
     keyserver: keyserver.ubuntu.com

--- a/tests/integration/targets/setup_proxysql/vars/main.yml
+++ b/tests/integration/targets/setup_proxysql/vars/main.yml
@@ -2,11 +2,11 @@
 proxysql_release: "{{ proxysql_download_src }}/v{{ proxysql_version }}/proxysql_{{ proxysql_version }}-{{ ansible_lsb.id | lower }}{{ ansible_lsb.major_release }}_amd64.deb"
 
 proxysql_percona_mysql_repos:
-  - deb http://repo.percona.com/apt {{ ansible_lsb.codename }} main
-  - deb-src http://repo.percona.com/apt {{ ansible_lsb.codename }} main
+  - deb https://repo.percona.com/ps-80/apt {{ ansible_lsb.codename }} main
+  - deb-src https://repo.percona.com/ps-80/apt {{ ansible_lsb.codename }} main
 
 proxysql_percona_mysql_packages:
-  - percona-server-client-{{ proxysql_mysql_client_version }}
+  - percona-server-client
   - python3-mysqldb
 
 proxysql_python_packages:

--- a/tests/integration/targets/test_proxysql_backend_servers/tasks/test_create_backend_server.yml
+++ b/tests/integration/targets/test_proxysql_backend_servers/tasks/test_create_backend_server.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create server reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_backend_servers_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_backend_servers_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create server did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_backend_servers/tasks/test_create_backend_server_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_backend_servers/tasks/test_create_backend_server_in_memory_only.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create server reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_backend_servers_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_backend_servers_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create server did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_backend_servers/tasks/test_create_backend_server_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_backend_servers/tasks/test_create_backend_server_with_delayed_persist.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create server reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_backend_servers_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_backend_servers_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create server did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_backend_servers/tasks/test_delete_backend_server.yml
+++ b/tests/integration/targets/test_proxysql_backend_servers/tasks/test_delete_backend_server.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete server reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_backend_servers_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_backend_servers_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete server did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_backend_servers/tasks/test_delete_backend_server_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_backend_servers/tasks/test_delete_backend_server_in_memory_only.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete server reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_backend_servers_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_backend_servers_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete server didn't make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_backend_servers/tasks/test_delete_backend_server_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_backend_servers/tasks/test_delete_backend_server_with_delayed_persist.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete server reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_backend_servers_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_backend_servers_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete server did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_create_galera_hostgroups.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_create_galera_hostgroups.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create galera hostgroups reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_galera_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_galera_hostgroups_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_create_galera_hostgroups_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_create_galera_hostgroups_in_memory_only.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create galera hostgroups reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_galera_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_galera_hostgroups_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_create_galera_hostgroups_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_create_galera_hostgroups_with_delayed_persist.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create galera hostgroups reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_galera_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_galera_hostgroups_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create galera hostgroups did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_delete_galera_hostgroups.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_delete_galera_hostgroups.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete galera hostgroups reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_galera_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_galera_hostgroups_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_delete_galera_hostgroups_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_delete_galera_hostgroups_in_memory_only.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete galera hostgroups reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_galera_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_galera_hostgroups_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups didn't make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_delete_galera_hostgroups_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_galera_hostgroups/tasks/test_delete_galera_hostgroups_with_delayed_persist.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete galera hostgroups reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_galera_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_galera_hostgroups_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete galera hostgroups did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_global_variables/tasks/test_update_variable_value.yml
+++ b/tests/integration/targets/test_proxysql_global_variables/tasks/test_update_variable_value.yml
@@ -9,20 +9,19 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if updating variable value reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_global_variables_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_global_variables_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value did make a change in memory"
   assert:
-    that: memory_result.stdout == updated_variable_value
+    that: (memory_result.stdout|int) == updated_variable_value
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value did make a change on disk"
   assert:
-    that: disk_result.stdout == updated_variable_value
+    that: (disk_result.stdout|int) == updated_variable_value
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value did make a change to runtime"
   assert:
-    that: runtime_result.stdout == updated_variable_value
+    that: (runtime_result.stdout|int) == updated_variable_value
 
 ### perform cleanup
 

--- a/tests/integration/targets/test_proxysql_global_variables/tasks/test_update_variable_value.yml
+++ b/tests/integration/targets/test_proxysql_global_variables/tasks/test_update_variable_value.yml
@@ -13,15 +13,15 @@
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value did make a change in memory"
   assert:
-    that: (memory_result.stdout|int) == updated_variable_value
+    that: memory_result.stdout == (updated_variable_value|string)
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value did make a change on disk"
   assert:
-    that: (disk_result.stdout|int) == updated_variable_value
+    that: disk_result.stdout == (updated_variable_value|string)
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value did make a change to runtime"
   assert:
-    that: (runtime_result.stdout|int) == updated_variable_value
+    that: runtime_result.stdout == (updated_variable_value|string)
 
 ### perform cleanup
 

--- a/tests/integration/targets/test_proxysql_global_variables/tasks/test_update_variable_value_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_global_variables/tasks/test_update_variable_value_in_memory_only.yml
@@ -9,12 +9,11 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if updating variable value reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_global_variables_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_global_variables_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value did make a change in memory"
   assert:
-    that: memory_result.stdout == updated_variable_value
+    that: (memory_result.stdout|int) == updated_variable_value
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value didn't make a change on disk"
   assert:

--- a/tests/integration/targets/test_proxysql_global_variables/tasks/test_update_variable_value_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_global_variables/tasks/test_update_variable_value_in_memory_only.yml
@@ -13,15 +13,15 @@
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value did make a change in memory"
   assert:
-    that: (memory_result.stdout|int) == updated_variable_value
+    that: memory_result.stdout == (updated_variable_value|string)
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value didn't make a change on disk"
   assert:
-    that: disk_result.stdout == original_variable_value
+    that: disk_result.stdout == (original_variable_value|string)
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value didn't make a change to runtime"
   assert:
-    that: runtime_result.stdout == original_variable_value
+    that: runtime_result.stdout == (original_variable_value|string)
 
 ### perform cleanup
 

--- a/tests/integration/targets/test_proxysql_global_variables/tasks/test_update_variable_value_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_global_variables/tasks/test_update_variable_value_with_delayed_persist.yml
@@ -9,20 +9,19 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if updating variable value reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_global_variables_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_global_variables_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value did make a change in memory"
   assert:
-    that: memory_result.stdout == updated_variable_value
+    that: (memory_result.stdout|int) == updated_variable_value
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value did make a change on disk"
   assert:
-    that: disk_result.stdout == updated_variable_value
+    that: (disk_result.stdout|int) == updated_variable_value
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value did make a change to runtime"
   assert:
-    that: runtime_result.stdout == updated_variable_value
+    that: (runtime_result.stdout|int) == updated_variable_value
 
 ### perform cleanup
 

--- a/tests/integration/targets/test_proxysql_global_variables/tasks/test_update_variable_value_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_global_variables/tasks/test_update_variable_value_with_delayed_persist.yml
@@ -13,15 +13,15 @@
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value did make a change in memory"
   assert:
-    that: (memory_result.stdout|int) == updated_variable_value
+    that: memory_result.stdout == (updated_variable_value|string)
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value did make a change on disk"
   assert:
-    that: (disk_result.stdout|int) == updated_variable_value
+    that: disk_result.stdout == (updated_variable_value|string)
 
 - name: "{{ role_name }} | {{ current_test }} | confirm updating variable value did make a change to runtime"
   assert:
-    that: (runtime_result.stdout|int) == updated_variable_value
+    that: runtime_result.stdout == (updated_variable_value|string)
 
 ### perform cleanup
 

--- a/tests/integration/targets/test_proxysql_mysql_users/tasks/test_create_mysql_user.yml
+++ b/tests/integration/targets/test_proxysql_mysql_users/tasks/test_create_mysql_user.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | check if create user reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_mysql_users_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_mysql_users_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | confirm create user did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_mysql_users/tasks/test_create_mysql_user_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_mysql_users/tasks/test_create_mysql_user_in_memory_only.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | check if create user reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_mysql_users_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_mysql_users_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | confirm create user did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_mysql_users/tasks/test_create_mysql_user_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_mysql_users/tasks/test_create_mysql_user_with_delayed_persist.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | check if create user reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_mysql_users_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_mysql_users_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | confirm create user did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_mysql_users/tasks/test_delete_mysql_user.yml
+++ b/tests/integration/targets/test_proxysql_mysql_users/tasks/test_delete_mysql_user.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | check if delete user reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_mysql_users_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_mysql_users_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | confirm delete user did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_mysql_users/tasks/test_delete_mysql_user_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_mysql_users/tasks/test_delete_mysql_user_in_memory_only.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | {{ encryption_method }} | check if delete user reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_mysql_users_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_mysql_users_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | {{ encryption_method }} | confirm delete user didn't make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_mysql_users/tasks/test_delete_mysql_user_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_mysql_users/tasks/test_delete_mysql_user_with_delayed_persist.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | {{ encryption_method }} |check if delete user reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_mysql_users_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_mysql_users_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | {{ encryption_method }} | confirm delete user did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_mysql_users_sha2/tasks/test_create_mysql_user.yml
+++ b/tests/integration/targets/test_proxysql_mysql_users_sha2/tasks/test_create_mysql_user.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | check if create user reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_mysql_users_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_mysql_users_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | confirm create user did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_mysql_users_sha2/tasks/test_create_mysql_user_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_mysql_users_sha2/tasks/test_create_mysql_user_in_memory_only.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | check if create user reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_mysql_users_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_mysql_users_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | confirm create user did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_mysql_users_sha2/tasks/test_create_mysql_user_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_mysql_users_sha2/tasks/test_create_mysql_user_with_delayed_persist.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | check if create user reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_mysql_users_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_mysql_users_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | confirm create user did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_mysql_users_sha2/tasks/test_delete_mysql_user.yml
+++ b/tests/integration/targets/test_proxysql_mysql_users_sha2/tasks/test_delete_mysql_user.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | check if delete user reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_mysql_users_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_mysql_users_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ encryption_method }} |  {{ current_test }} | confirm delete user did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_mysql_users_sha2/tasks/test_delete_mysql_user_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_mysql_users_sha2/tasks/test_delete_mysql_user_in_memory_only.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | {{ encryption_method }} | check if delete user reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_mysql_users_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_mysql_users_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | {{ encryption_method }} | confirm delete user didn't make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_mysql_users_sha2/tasks/test_delete_mysql_user_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_mysql_users_sha2/tasks/test_delete_mysql_user_with_delayed_persist.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | {{ encryption_method }} |check if delete user reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_mysql_users_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_mysql_users_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | {{ encryption_method }} | confirm delete user did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_query_rules/tasks/test_create_query_rule.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/tasks/test_create_query_rule.yml
@@ -12,8 +12,7 @@
   block:
     - name: "{{ role_name }} | {{ current_test }} | check if create query rule reported a change"
       assert:
-        that:
-          - "status is {{ test_proxysql_query_rules_check_idempotence|ternary('not changed', 'changed') }}"
+        that: 'test_proxysql_query_rules_check_idempotence | ternary(status is not changed, status is changed)'
 
     - name: "{{ role_name }} | {{ current_test }} | confirm create query rule did make a change in memory"
       assert:
@@ -32,8 +31,7 @@
   block:
     - name: "{{ role_name }} | {{ current_test }} | check if create query rule reported a change"
       assert:
-        that:
-          - "status1 is {{ test_proxysql_query_rules_check_idempotence|ternary('not changed', 'changed') }}"
+        that: 'test_proxysql_query_rules_check_idempotence | ternary(status1 is not changed, status1 is changed)'
 
     - name: "{{ role_name }} | {{ current_test }} | confirm create query rule did make a change in memory"
       assert:

--- a/tests/integration/targets/test_proxysql_query_rules/tasks/test_create_query_rule_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/tasks/test_create_query_rule_in_memory_only.yml
@@ -11,8 +11,7 @@
   block:
     - name: "{{ role_name }} | {{ current_test }} | check if create query rule reported a change"
       assert:
-        that:
-          - "status is {{ test_proxysql_query_rules_check_idempotence|ternary('not changed', 'changed') }}"
+        that: 'test_proxysql_query_rules_check_idempotence | ternary(status is not changed, status is changed)'
 
     - name: "{{ role_name }} | {{ current_test }} | confirm create query rule did make a change in memory"
       assert:
@@ -31,8 +30,7 @@
   block:
     - name: "{{ role_name }} | {{ current_test }} | check if create query rule reported a change"
       assert:
-        that:
-          - "status1 is {{ test_proxysql_query_rules_check_idempotence|ternary('not changed', 'changed') }}"
+        that: 'test_proxysql_query_rules_check_idempotence | ternary(status1 is not changed, status1 is changed)'
 
     - name: "{{ role_name }} | {{ current_test }} | confirm create query rule did make a change in memory"
       assert:

--- a/tests/integration/targets/test_proxysql_query_rules/tasks/test_create_query_rule_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/tasks/test_create_query_rule_with_delayed_persist.yml
@@ -12,8 +12,7 @@
   block:
     - name: "{{ role_name }} | {{ current_test }} | check if create query rule reported a change"
       assert:
-        that:
-          - "status is {{ test_proxysql_query_rules_check_idempotence|ternary('not changed', 'changed') }}"
+        that: 'test_proxysql_query_rules_check_idempotence | ternary(status is not changed, status is changed)'
 
     - name: "{{ role_name }} | {{ current_test }} | confirm create query rule did make a change in memory"
       assert:
@@ -32,8 +31,7 @@
   block:
     - name: "{{ role_name }} | {{ current_test }} | check if create query rule reported a change"
       assert:
-        that:
-          - "status1 is {{ test_proxysql_query_rules_check_idempotence|ternary('not changed', 'changed') }}"
+        that: 'test_proxysql_query_rules_check_idempotence | ternary(status1 is not changed, status1 is changed)'
 
     - name: "{{ role_name }} | {{ current_test }} | confirm create query rule did make a change in memory"
       assert:

--- a/tests/integration/targets/test_proxysql_query_rules/tasks/test_delete_query_rule.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/tasks/test_delete_query_rule.yml
@@ -12,8 +12,7 @@
   block:
     - name: "{{ role_name }} | {{ current_test }} | check if delete query rule reported a change"
       assert:
-        that:
-          - "status is {{ test_proxysql_query_rules_check_idempotence|ternary('not changed', 'changed') }}"
+        that: 'test_proxysql_query_rules_check_idempotence | ternary(status is not changed, status is changed)'
 
     - name: "{{ role_name }} | {{ current_test }} | confirm delete query rule did make a change in memory"
       assert:
@@ -32,8 +31,7 @@
   block:
     - name: "{{ role_name }} | {{ current_test }} | check if delete query rule reported a change"
       assert:
-        that:
-          - "status1 is {{ test_proxysql_query_rules_check_idempotence|ternary('not changed', 'changed') }}"
+        that: 'test_proxysql_query_rules_check_idempotence | ternary(status1 is not changed, status1 is changed)'
 
     - name: "{{ role_name }} | {{ current_test }} | confirm delete query rule did make a change in memory"
       assert:

--- a/tests/integration/targets/test_proxysql_query_rules/tasks/test_delete_query_rule_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/tasks/test_delete_query_rule_in_memory_only.yml
@@ -12,8 +12,7 @@
   block:
     - name: "{{ role_name }} | {{ current_test }} | check if delete query rule reported a change"
       assert:
-        that:
-          - "status is {{ test_proxysql_query_rules_check_idempotence|ternary('not changed', 'changed') }}"
+        that: 'test_proxysql_query_rules_check_idempotence | ternary(status is not changed, status is changed)'
 
     - name: "{{ role_name }} | {{ current_test }} | confirm delete query rule didn't make a change in memory"
       assert:
@@ -32,8 +31,7 @@
   block:
     - name: "{{ role_name }} | {{ current_test }} | check if delete query rule reported a change"
       assert:
-        that:
-          - "status1 is {{ test_proxysql_query_rules_check_idempotence|ternary('not changed', 'changed') }}"
+        that: 'test_proxysql_query_rules_check_idempotence | ternary(status1 is not changed, status1 is changed)'
 
     - name: "{{ role_name }} | {{ current_test }} | confirm delete query rule didn't make a change in memory"
       assert:

--- a/tests/integration/targets/test_proxysql_query_rules/tasks/test_delete_query_rule_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_query_rules/tasks/test_delete_query_rule_with_delayed_persist.yml
@@ -11,8 +11,7 @@
   block:
     - name: "{{ role_name }} | {{ current_test }} | check if delete query rule reported a change"
       assert:
-        that:
-          - "status is {{ test_proxysql_query_rules_check_idempotence|ternary('not changed', 'changed') }}"
+        that: 'test_proxysql_query_rules_check_idempotence | ternary(status is not changed, status is changed)'
 
     - name: "{{ role_name }} | {{ current_test }} | confirm delete query rule did make a change in memory"
       assert:
@@ -32,7 +31,7 @@
     - name: "{{ role_name }} | {{ current_test }} | check if delete query rule reported a change"
       assert:
         that:
-          - "status1 is {{ test_proxysql_query_rules_check_idempotence|ternary('not changed', 'changed') }}"
+          that: 'test_proxysql_query_rules_check_idempotence | ternary(status1 is not changed, status1 is changed)'
 
     - name: "{{ role_name }} | {{ current_test }} | confirm delete query rule did make a change in memory"
       assert:

--- a/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/test_create_query_rule_fast_routing.yml
+++ b/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/test_create_query_rule_fast_routing.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create query rule fast routing reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_query_rules_fast_routing_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_query_rules_fast_routing_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create query rule fast routing did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/test_create_query_rule_fast_routing_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/test_create_query_rule_fast_routing_in_memory_only.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create query rule fast routing reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_query_rules_fast_routing_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_query_rules_fast_routing_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create query rule fast routing did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/test_create_query_rule_fast_routing_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/test_create_query_rule_fast_routing_with_delayed_persist.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create query rule fast routing reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_query_rules_fast_routing_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_query_rules_fast_routing_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create query rule fast routing did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/test_delete_query_rule_fast_routing.yml
+++ b/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/test_delete_query_rule_fast_routing.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete query rule fast routing reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_query_rules_fast_routing_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_query_rules_fast_routing_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete query rule fast routing did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/test_delete_query_rule_fast_routing_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/test_delete_query_rule_fast_routing_in_memory_only.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete query rule fast routing reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_query_rules_fast_routing_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_query_rules_fast_routing_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete query rule fast routing didn't make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/test_delete_query_rule_fast_routing_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_query_rules_fast_routing/tasks/test_delete_query_rule_fast_routing_with_delayed_persist.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete query rule fast routing reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_query_rules_fast_routing_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_query_rules_fast_routing_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete query rule fast routing did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_replication_hostgroups/tasks/test_create_replication_hostgroups.yml
+++ b/tests/integration/targets/test_proxysql_replication_hostgroups/tasks/test_create_replication_hostgroups.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create replication hostgroups reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_replication_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_replication_hostgroups_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create replication hostgroups did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_replication_hostgroups/tasks/test_create_replication_hostgroups_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_replication_hostgroups/tasks/test_create_replication_hostgroups_in_memory_only.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create replication hostgroups reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_replication_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_replication_hostgroups_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create replication hostgroups did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_replication_hostgroups/tasks/test_create_replication_hostgroups_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_replication_hostgroups/tasks/test_create_replication_hostgroups_with_delayed_persist.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create replication hostgroups reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_replication_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_replication_hostgroups_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create replication hostgroups did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_replication_hostgroups/tasks/test_delete_replication_hostgroups.yml
+++ b/tests/integration/targets/test_proxysql_replication_hostgroups/tasks/test_delete_replication_hostgroups.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete replication hostgroups reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_replication_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_replication_hostgroups_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete replication hostgroups did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_replication_hostgroups/tasks/test_delete_replication_hostgroups_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_replication_hostgroups/tasks/test_delete_replication_hostgroups_in_memory_only.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete replication hostgroups reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_replication_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_replication_hostgroups_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete replication hostgroups didn't make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_replication_hostgroups/tasks/test_delete_replication_hostgroups_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_replication_hostgroups/tasks/test_delete_replication_hostgroups_with_delayed_persist.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete replication hostgroups reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_replication_hostgroups_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_replication_hostgroups_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete replication hostgroups did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_scheduler/tasks/test_create_scheduler.yml
+++ b/tests/integration/targets/test_proxysql_scheduler/tasks/test_create_scheduler.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create scheduler reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_scheduler_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_scheduler_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create scheduler did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_scheduler/tasks/test_create_scheduler_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_scheduler/tasks/test_create_scheduler_in_memory_only.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create scheduler reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_scheduler_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_scheduler_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create scheduler did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_scheduler/tasks/test_create_scheduler_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_scheduler/tasks/test_create_scheduler_with_delayed_persist.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if create scheduler reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_scheduler_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_scheduler_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm create scheduler did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_scheduler/tasks/test_delete_scheduler.yml
+++ b/tests/integration/targets/test_proxysql_scheduler/tasks/test_delete_scheduler.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete scheduler reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_scheduler_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_scheduler_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete scheduler did make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_scheduler/tasks/test_delete_scheduler_in_memory_only.yml
+++ b/tests/integration/targets/test_proxysql_scheduler/tasks/test_delete_scheduler_in_memory_only.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete scheduler reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_scheduler_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_scheduler_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete scheduler didn't make a change in memory"
   assert:

--- a/tests/integration/targets/test_proxysql_scheduler/tasks/test_delete_scheduler_with_delayed_persist.yml
+++ b/tests/integration/targets/test_proxysql_scheduler/tasks/test_delete_scheduler_with_delayed_persist.yml
@@ -9,8 +9,7 @@
 
 - name: "{{ role_name }} | {{ current_test }} | check if delete scheduler reported a change"
   assert:
-    that:
-      - "status is {{ test_proxysql_scheduler_check_idempotence|ternary('not changed', 'changed') }}"
+    that: 'test_proxysql_scheduler_check_idempotence | ternary(status is not changed, status is changed)'
 
 - name: "{{ role_name }} | {{ current_test }} | confirm delete scheduler did make a change in memory"
   assert:


### PR DESCRIPTION
##### SUMMARY
This commit makes the necessary changes to run integration tests with Ansible 2.16 through Ansible 2.19. Because Ansible 2.19 does not work with any Ubuntu release that supports Percona Server 5.7, this commit upgrades the `percona-server-client` to version 8.0, which is currently the oldest supported release of Percona Server.

This commit was large enough that it didn't fix the Ansible 2.19 warnings, just the errors, but does begin to address #174.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
All integration tests.