### PR TITLE
Remove dependency on six.

### DIFF
--- a/plugins/module_utils/mysql.py
+++ b/plugins/module_utils/mysql.py
@@ -13,8 +13,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import configparser
 
-from ansible.module_utils.six.moves import configparser
 from ansible.module_utils.basic import missing_required_lib
 from hashlib import sha256
 from os import urandom

--- a/plugins/modules/proxysql_backend_servers.py
+++ b/plugins/modules/proxysql_backend_servers.py
@@ -166,7 +166,6 @@ from ansible_collections.community.proxysql.plugins.module_utils.mysql import (
     save_config_to_disk,
     load_config_to_runtime,
 )
-from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
 
 # ===========================================
@@ -249,7 +248,7 @@ class ProxySQLServer(object):
              self.hostname,
              self.port]
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 query_data.append(val)
                 query_string += "\n  AND " + col + " = %s"
@@ -292,7 +291,7 @@ class ProxySQLServer(object):
              self.hostname,
              self.port]
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 cols += 1
                 query_data.append(val)
@@ -315,7 +314,7 @@ class ProxySQLServer(object):
         cols = 0
         query_data = []
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 cols += 1
                 query_data.append(val)

--- a/plugins/modules/proxysql_mysql_users.py
+++ b/plugins/modules/proxysql_mysql_users.py
@@ -177,7 +177,6 @@ from ansible_collections.community.proxysql.plugins.module_utils.mysql import (
     mysql_sha256_password_hash,
     generate_random_salt,
 )
-from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native, to_bytes
 from hashlib import sha1
 
@@ -271,7 +270,7 @@ class ProxySQLUser(object):
              self.backend,
              self.frontend]
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 query_data.append(val)
                 query_string += "\n  AND " + col + " = %s"
@@ -310,7 +309,7 @@ class ProxySQLUser(object):
              self.backend,
              self.frontend]
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 cols += 1
                 query_data.append(val)
@@ -333,7 +332,7 @@ class ProxySQLUser(object):
         cols = 0
         query_data = []
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 cols += 1
                 query_data.append(val)

--- a/plugins/modules/proxysql_query_rules.py
+++ b/plugins/modules/proxysql_query_rules.py
@@ -362,7 +362,6 @@ from ansible_collections.community.proxysql.plugins.module_utils.mysql import (
     save_config_to_disk,
     load_config_to_runtime,
 )
-from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
 
 # ===========================================
@@ -436,7 +435,7 @@ class ProxyQueryRule(object):
         cols = 0
         query_data = []
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 cols += 1
                 query_data.append(val)
@@ -467,7 +466,7 @@ class ProxyQueryRule(object):
             cols = 0
             query_data = []
 
-            for col, val in iteritems(self.config_data):
+            for col, val in self.config_data.items():
                 if val is not None:
                     cols += 1
                     query_data.append(val)
@@ -491,7 +490,7 @@ class ProxyQueryRule(object):
         cols = 0
         query_data = []
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 cols += 1
                 query_data.append(val)
@@ -517,7 +516,7 @@ class ProxyQueryRule(object):
         cols = 0
         query_data = []
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None and col != "rule_id":
                 cols += 1
                 query_data.append(val)
@@ -541,7 +540,7 @@ class ProxyQueryRule(object):
         cols = 0
         query_data = []
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 cols += 1
                 query_data.append(val)

--- a/plugins/modules/proxysql_query_rules_fast_routing.py
+++ b/plugins/modules/proxysql_query_rules_fast_routing.py
@@ -114,7 +114,6 @@ from ansible_collections.community.proxysql.plugins.module_utils.mysql import (
     save_config_to_disk,
     load_config_to_runtime,
 )
-from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
 
 # ===========================================
@@ -168,7 +167,7 @@ class ProxyQueryRuleFastRouting(object):
         cols = 0
         query_data = []
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 cols += 1
                 query_data.append(val)
@@ -199,7 +198,7 @@ class ProxyQueryRuleFastRouting(object):
             self.config_data["flagIN"]
         ]
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 query_data.append(val)
                 query_string += " AND " + col + " = %s"
@@ -214,7 +213,7 @@ class ProxyQueryRuleFastRouting(object):
         cols = 0
         query_data = []
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 cols += 1
                 query_data.append(val)
@@ -238,7 +237,7 @@ class ProxyQueryRuleFastRouting(object):
             self.config_data["flagIN"]
         ]
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None and col not in ("username", "schemaname", "flagIN"):
                 query_data.insert(cols, val)
                 cols += 1
@@ -263,7 +262,7 @@ class ProxyQueryRuleFastRouting(object):
         cols = 0
         query_data = []
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 cols += 1
                 query_data.append(val)

--- a/plugins/modules/proxysql_scheduler.py
+++ b/plugins/modules/proxysql_scheduler.py
@@ -142,7 +142,6 @@ from ansible_collections.community.proxysql.plugins.module_utils.mysql import (
     save_config_to_disk,
     load_config_to_runtime,
 )
-from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
 
 # ===========================================
@@ -192,7 +191,7 @@ class ProxySQLSchedule(object):
              self.interval_ms,
              self.filename]
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 query_data.append(val)
                 query_string += "\n  AND " + col + " = %s"
@@ -214,7 +213,7 @@ class ProxySQLSchedule(object):
              self.interval_ms,
              self.filename]
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 query_data.append(val)
                 query_string += "\n  AND " + col + " = %s"
@@ -236,7 +235,7 @@ class ProxySQLSchedule(object):
              self.interval_ms,
              self.filename]
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 cols += 1
                 query_data.append(val)
@@ -263,7 +262,7 @@ class ProxySQLSchedule(object):
              self.interval_ms,
              self.filename]
 
-        for col, val in iteritems(self.config_data):
+        for col, val in self.config_data.items():
             if val is not None:
                 query_data.append(val)
                 query_string += "\n  AND " + col + " = %s"


### PR DESCRIPTION
##### SUMMARY

As per ansible/ansible#85651, the development branch of Ansible has marked use of the `six` dependency as deprecated. This commit removes the dependency.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Sanity tests

##### ADDITIONAL INFORMATION

This fixes the new sanity test failures in mainline after last merge:

```
ERROR: Found 5 pylint issue(s) which need to be resolved:
ERROR: plugins/modules/proxysql_backend_servers.py:169:0: ansible-bad-import-from: Import iteritems from the Python standard library equivalent instead of ansible.module_utils.six
ERROR: plugins/modules/proxysql_mysql_users.py:180:0: ansible-bad-import-from: Import iteritems from the Python standard library equivalent instead of ansible.module_utils.six
ERROR: plugins/modules/proxysql_query_rules.py:365:0: ansible-bad-import-from: Import iteritems from the Python standard library equivalent instead of ansible.module_utils.six
ERROR: plugins/modules/proxysql_query_rules_fast_routing.py:117:0: ansible-bad-import-from: Import iteritems from the Python standard library equivalent instead of ansible.module_utils.six
ERROR: plugins/modules/proxysql_scheduler.py:145:0: ansible-bad-import-from: Import iteritems from the Python standard library equivalent instead of ansible.module_utils.six
```
